### PR TITLE
Fix missing attribute for new Payroll Indonesia Settings

### DIFF
--- a/payroll_indonesia/setup/settings_migration.py
+++ b/payroll_indonesia/setup/settings_migration.py
@@ -121,7 +121,7 @@ def migrate_all_settings(settings_doc=None, defaults=None, *args, **kwargs) -> D
     results["gl_account_mappings"] = _seed_gl_account_mappings(settings_doc, defaults)
 
     # Save if we created the settings doc
-    if settings_doc._doc_before_save is None:
+    if not getattr(settings_doc, "_doc_before_save", None):
         settings_doc.save()
 
     # Log summary


### PR DESCRIPTION
## Summary
- avoid AttributeError during settings migration on fresh installs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6869368dcac8832ca69bbae4a8d7699e