### PR TITLE
Add hook wrappers for Payroll Entry and Salary Slip

### DIFF
--- a/payroll_indonesia/override/payroll_entry.py
+++ b/payroll_indonesia/override/payroll_entry.py
@@ -247,3 +247,13 @@ def setup_hooks() -> None:
 
 # Set up hooks when module is loaded
 setup_hooks()
+
+
+def validate(doc, method=None):
+    """Wrapper for Payroll Entry validate event."""
+    return CustomPayrollEntry.validate(doc)
+
+
+def on_submit(doc, method=None):
+    """Wrapper for Payroll Entry on_submit event."""
+    return CustomPayrollEntry.on_submit(doc)

--- a/payroll_indonesia/override/salary_slip/payroll_controller.py
+++ b/payroll_indonesia/override/salary_slip/payroll_controller.py
@@ -21,6 +21,8 @@ import payroll_indonesia.override.salary_slip.tax_calculator as tax_calc
 import payroll_indonesia.override.salary_slip.ter_calculator as ter_calc
 import payroll_indonesia.payroll_indonesia.validations as val
 
+__all__ = ["on_submit", "on_cancel"]
+
 logger = logging.getLogger("payroll_controller")
 
 
@@ -179,3 +181,14 @@ class PayrollController:
         )
 
         logger.info(f"Updated YTD records for employee {employee}")
+
+
+def on_submit(doc, method=None):
+    """Salary Slip on_submit hook."""
+    PayrollController(doc).on_submit()
+
+
+def on_cancel(doc, method=None):
+    """Salary Slip on_cancel hook."""
+    # implement cancellation logic or leave as pass
+    pass


### PR DESCRIPTION
## Summary
- expose wrapper functions for Payroll Entry validate and submit events
- add Salary Slip event hooks in `payroll_controller`
- export salary slip hooks via `__all__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_686962912e28832cb036daf7f43fad5a