### PR TITLE
Add EmployeeOverride class

### DIFF
--- a/payroll_indonesia/override/employee.py
+++ b/payroll_indonesia/override/employee.py
@@ -5,6 +5,15 @@
 
 import frappe
 from frappe import _
+from hrms.payroll.doctype.employee.employee import Employee
+
+
+class EmployeeOverride(Employee):
+    """Custom Employee class for Payroll Indonesia."""
+
+    pass
+
+__all__ = ["EmployeeOverride", "validate", "on_update", "create_custom_fields"]
 
 
 def validate(doc, method):


### PR DESCRIPTION
## Summary
- implement `EmployeeOverride` in `override/employee.py`
- export functions and class with `__all__`

## Testing
- `python -m py_compile payroll_indonesia/override/employee.py`
- *(fail: missing `frappe` when importing hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6869dd2dfe2c832c8c067cf5b37144e0