### PR TITLE
Fix BPJS mapping update hook

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/bpjs_account_mapping.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/bpjs_account_mapping.py
@@ -36,18 +36,8 @@ def validate(doc, method=None):
 
 
 def on_update(doc, method=None):
-    """
-    Global on_update hook for BPJS Account Mapping document.
-    Called by hooks after document is updated.
-
-    Args:
-        doc: The document being updated
-        method: The method that triggered this hook (optional)
-    """
-    doc.on_update()
-    
-    # Optionally sync to settings
-    sync_to_settings(doc)
+    """Clear cached mapping for the updated company."""
+    frappe.cache().delete_value(f"bpjs_mapping_{doc.company}")
 
 
 def sync_to_settings(doc, method=None):


### PR DESCRIPTION
## Summary
- simplify the module level `on_update` for BPJS mapping

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6869dd867b54832c92135357051618be