### PR TITLE
Fix setup_accounts income tax slab call

### DIFF
--- a/payroll_indonesia/setup/setup_module.py
+++ b/payroll_indonesia/setup/setup_module.py
@@ -78,9 +78,9 @@ def setup_accounts() -> bool:
             if key not in defaults:
                 defaults[key] = value
     
-    # Setup Income Tax Slab with new signature
+    # Setup Income Tax Slab
     try:
-        result = setup_income_tax_slab(defaults)
+        result = setup_income_tax_slab()
         results["income_tax_slab"] = result
         if result:
             logger.info("Income Tax Slab setup completed successfully")


### PR DESCRIPTION
## Summary
- call `setup_income_tax_slab()` without defaults in `setup_accounts`
- remove outdated comment about new signature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6869dd8878dc832c874ce56e8c5c9089