### PR TITLE
Implement initialize_fields in Salary Slip functions

### DIFF
--- a/payroll_indonesia/override/salary_slip_functions.py
+++ b/payroll_indonesia/override/salary_slip_functions.py
@@ -20,13 +20,30 @@ from payroll_indonesia.payroll_indonesia.utils import calculate_bpjs
 
 # Define public API
 __all__ = [
-    "update_component_amount", 
+    "update_component_amount",
+    "initialize_fields",
     "salary_slip_post_submit",
-    "calculate_monthly_pro_rata", 
+    "calculate_monthly_pro_rata",
     "calculate_tax_amount",
     "calculate_employer_contributions",
     "get_salary_components_from_structure"
 ]
+
+
+def initialize_fields(doc, method: Optional[str] = None) -> None:
+    """Ensure custom Salary Slip fields are initialized with defaults."""
+    defaults = {
+        "biaya_jabatan": 0,
+        "netto": 0,
+        "total_bpjs": 0,
+        "is_using_ter": 0,
+        "ter_rate": 0,
+        "koreksi_pph21": 0,
+    }
+
+    for field, default in defaults.items():
+        if not hasattr(doc, field) or getattr(doc, field) is None:
+            setattr(doc, field, default)
 
 
 def update_component_amount(doc, method: Optional[str] = None) -> None:


### PR DESCRIPTION
## Summary
- default custom fields after creating Salary Slip
- export initialize_fields so hooks can import it

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6869f725aeb8832c87c564ee260763ab