### PR TITLE
Add CONTRIBUTING guide for local testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to Payroll Indonesia
+
+This project relies on the Frappe Framework and ERPNext. To run the test suite locally you need a working bench environment with ERPNext installed.
+
+## 1. Create a bench environment
+
+```bash
+# install bench if not already available
+pip install frappe-bench
+
+# create a new bench using the ERPNext 15 branch
+bench init payroll-bench --frappe-branch version-15
+cd payroll-bench
+
+# fetch ERPNext
+bench get-app erpnext --branch version-15
+```
+
+## 2. Create a site
+
+```bash
+bench new-site test.local
+bench --site test.local install-app erpnext
+```
+
+## 3. Install Payroll Indonesia
+
+Clone this repository inside your bench `apps` directory:
+
+```bash
+cd apps
+git clone https://github.com/dannyaudian/payroll_indonesia.git
+cd ..
+bench --site test.local install-app payroll_indonesia
+```
+
+## 4. Run the tests
+
+Activate developer mode so the site can run tests and then execute `pytest` through bench:
+
+```bash
+bench --site test.local set-config developer_mode 1
+bench --site test.local run-tests --app payroll_indonesia
+```
+
+This command will launch `pytest` with Frappe's test runner so all tests in `payroll_indonesia/payroll_indonesia/tests` are executed against the created site.
+
+

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ The Payroll Indonesia module is modularly optimized to provide top performance a
 * Efficient and clear logging using Python’s logging module.
 * Modular design featuring specialized utilities for BPJS, PPh21, YTD calculations, and field validations.
 
+## 🧑‍💻 Contributing
+
+For instructions on setting up Frappe/ERPNext so that `pytest` can run locally, see
+the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
+
 ## 📢 Status
 
 Actively developed and deployed across diverse production environments. For issue reporting and feature requests, visit our [GitHub Repository](https://github.com/dannyaudian/payroll_indonesia).


### PR DESCRIPTION
## Summary
- document how to set up a Frappe/ERPNext environment for tests in `CONTRIBUTING.md`
- link to the new guide from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_686a39d07d84832c9b7962d7e31d5094