### PR TITLE
Add unit test for tax summary wrapper

### DIFF
--- a/payroll_indonesia/payroll_indonesia/tests/test_update_employee_tax_summary.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_update_employee_tax_summary.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+import unittest
+from unittest.mock import patch
+
+from payroll_indonesia.payroll_indonesia import utils
+
+
+class TestUpdateEmployeeTaxSummary(unittest.TestCase):
+    @patch(
+        "payroll_indonesia.payroll_indonesia.doctype.employee_tax_summary.employee_tax_summary.create_from_salary_slip"
+    )
+    def test_calls_create_from_salary_slip(self, mock_create):
+        mock_create.return_value = "TAX-001"
+        result = utils.update_employee_tax_summary("EMP-001", "SS-001")
+        mock_create.assert_called_once_with("SS-001")
+        self.assertEqual(result, "TAX-001")
+
+    @patch("payroll_indonesia.payroll_indonesia.utils.logger")
+    @patch(
+        "payroll_indonesia.payroll_indonesia.doctype.employee_tax_summary.employee_tax_summary.create_from_salary_slip"
+    )
+    def test_logs_error_when_exception(self, mock_create, mock_logger):
+        mock_create.side_effect = Exception("boom")
+        result = utils.update_employee_tax_summary("EMP-001", "SS-001")
+        mock_create.assert_called_once_with("SS-001")
+        self.assertIsNone(result)
+        self.assertTrue(mock_logger.error.called)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/payroll_indonesia/payroll_indonesia/utils.py
+++ b/payroll_indonesia/payroll_indonesia/utils.py
@@ -32,6 +32,7 @@ __all__ = [
     "get_formatted_currency",
     "write_json_file_if_enabled",
     "cache_get_settings",
+    "update_employee_tax_summary",
 ]
 
 # Configure logger
@@ -578,6 +579,16 @@ def get_ter_rate_from_child(category: str, annual_income: float) -> float:
         f"using fallback {fallback_rate}%"
     )
     return fallback_rate
+
+
+@safe_execute(default_value=None)
+def update_employee_tax_summary(employee: str, salary_slip: str) -> Optional[str]:
+    """Wrapper to update Employee Tax Summary from a Salary Slip."""
+    from payroll_indonesia.payroll_indonesia.doctype.employee_tax_summary.employee_tax_summary import (
+        create_from_salary_slip,
+    )
+
+    return create_from_salary_slip(salary_slip)
 
 
 # For backward compatibility


### PR DESCRIPTION
## Summary
- implement `update_employee_tax_summary` wrapper in utils
- expose new helper in `__all__`
- add tests for tax summary update behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_686a39ca0430832cb0da2b22c1facc97