### PR TITLE
Add debug script and logging

### DIFF
--- a/payroll_indonesia/override/salary_slip_functions.py
+++ b/payroll_indonesia/override/salary_slip_functions.py
@@ -109,7 +109,17 @@ def update_component_amount(doc, method: Optional[str] = None) -> None:
     mapping = get_ptkp_to_ter_mapping()
     status_raw = str(getattr(doc, "status_pajak", "")).upper()
     ter_category = mapping.get(status_raw, "")
+
     is_ter_employee = bool(ter_category)
+
+    logger.warning(
+        "PPh21 route-check — slip=%s | status_raw=%s | ter_cat=%s | is_ter=%s | use_ter=%s",
+        doc.name,
+        status_raw,
+        ter_category,
+        is_ter_employee,
+        settings.use_ter,
+    )
 
     # Log key TER-related values for easier debugging of tax calculation logic
     logger.info(

--- a/scripts/debug_pph21_route.py
+++ b/scripts/debug_pph21_route.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import frappe
+
+from payroll_indonesia.payroll_indonesia import salary_slip_functions as ssf
+
+
+def main() -> None:
+    frappe.connect(site="itb_dev_lokal")  # ganti site Anda
+
+    # 1. Ensure settings
+    settings = frappe.get_cached_doc("Payroll Indonesia Settings")
+    settings.use_ter = 1
+    settings.tax_calculation_method = "TER"
+    settings.save(ignore_permissions=True)
+
+    # 2. Dummy employee
+    emp = frappe.new_doc("Employee")
+    emp.employee_name = "Debug TK1"
+    emp.status_pajak = "TK1"
+    emp.insert(ignore_permissions=True)
+
+    # 3. Dummy slip doc object (minimal attrs needed)
+    class DummySlip:
+        name = "SLIP-DEBUG"
+        employee = emp.name
+        status_pajak = emp.status_pajak
+        gross_pay = 10_000_000
+
+    tax = ssf.calculate_pph21(DummySlip())
+    print("Result tax:", tax)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- log warning when deciding between TER and progressive route
- add helper script to debug tax calculation

## Testing
- `black payroll_indonesia/override/salary_slip_functions.py scripts/debug_pph21_route.py --check`
- `python -m py_compile scripts/debug_pph21_route.py`
- `flake8 scripts/debug_pph21_route.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d390906e4832ca3d1132e8d71e5fd