### PR TITLE
Fix utils stubs in salary slip test

### DIFF
--- a/payroll_indonesia/payroll_indonesia/tests/test_salary_slip_post_submit.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_salary_slip_post_submit.py
@@ -60,6 +60,9 @@ def test_post_submit_updates_existing_history(monkeypatch):
     # minimal utils module used by salary_slip_functions
     pi_utils = types.ModuleType("payroll_indonesia.payroll_indonesia.utils")
     pi_utils.calculate_bpjs = lambda base_salary, rate_percent, max_salary=None: 0
+    # stub functions required by salary_slip_functions imports
+    pi_utils.get_ptkp_to_ter_mapping = lambda: {}
+    pi_utils.get_status_pajak = lambda doc: ""
     sys.modules["payroll_indonesia.payroll_indonesia.utils"] = pi_utils
 
     import importlib


### PR DESCRIPTION
## Summary
- patch `test_salary_slip_post_submit` to include stub implementations of `get_ptkp_to_ter_mapping` and `get_status_pajak`

## Testing
- `pytest payroll_indonesia/payroll_indonesia/tests/test_salary_slip_post_submit.py -q` *(fails: AttributeError in monkeypatch)*

------
https://chatgpt.com/codex/tasks/task_e_686d55ba3ec0832c80d16d00d6e5ee2d