### PR TITLE
Set manual tax fields on Salary Slip creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Salary slip creation now forces `tax_calculation_method` to "Manual" and clears `income_tax_slab`.

--- a/payroll_indonesia/override/payroll_entry_functions.py
+++ b/payroll_indonesia/override/payroll_entry_functions.py
@@ -170,6 +170,12 @@ def create_salary_slip(employee_data: Dict[str, Any], entry: Any) -> str:
     if salary_structure:
         slip.salary_structure = salary_structure
 
+    # Override automatic tax fields
+    if hasattr(slip, "tax_calculation_method"):
+        slip.tax_calculation_method = "Manual"
+    if hasattr(slip, "income_tax_slab"):
+        slip.income_tax_slab = None
+
     # Set December override flag
     slip.is_december_override = 1 if is_december_calculation(entry) else 0
 

--- a/payroll_indonesia/payroll_indonesia/tests/test_payroll_integration.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_payroll_integration.py
@@ -303,6 +303,12 @@ class TestPayrollIntegration(unittest.TestCase):
         salary_slip.append("earnings", {"salary_component": "Basic Salary", "amount": 15000000})
 
         salary_slip.gross_pay = 15000000
+
+        if hasattr(salary_slip, "tax_calculation_method"):
+            salary_slip.tax_calculation_method = "Manual"
+        if hasattr(salary_slip, "income_tax_slab"):
+            salary_slip.income_tax_slab = None
+
         salary_slip.insert()
 
         # Calculate tax components
@@ -384,6 +390,12 @@ class TestPayrollIntegration(unittest.TestCase):
         salary_slip.append("earnings", {"salary_component": "Basic Salary", "amount": 15000000})
 
         salary_slip.gross_pay = 15000000
+
+        if hasattr(salary_slip, "tax_calculation_method"):
+            salary_slip.tax_calculation_method = "Manual"
+        if hasattr(salary_slip, "income_tax_slab"):
+            salary_slip.income_tax_slab = None
+
         salary_slip.insert()
 
         # Calculate tax components
@@ -459,6 +471,12 @@ class TestPayrollIntegration(unittest.TestCase):
         salary_slip.append("earnings", {"salary_component": "Basic Salary", "amount": 15000000})
 
         salary_slip.gross_pay = 15000000
+
+        if hasattr(salary_slip, "tax_calculation_method"):
+            salary_slip.tax_calculation_method = "Manual"
+        if hasattr(salary_slip, "income_tax_slab"):
+            salary_slip.income_tax_slab = None
+
         salary_slip.insert()
 
         # Calculate tax components

--- a/payroll_indonesia/payroll_indonesia/tests/test_salary_components.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_salary_components.py
@@ -90,8 +90,23 @@ class TestSalaryComponents(unittest.TestCase):
 
             salary_slip.deductions = [{"salary_component": "BPJS TK", "amount": 100000}]
 
+        if hasattr(salary_slip, "tax_calculation_method"):
+            salary_slip.tax_calculation_method = "Manual"
+        if hasattr(salary_slip, "income_tax_slab"):
+            salary_slip.income_tax_slab = None
+
         salary_slip.insert(ignore_permissions=True)
         return salary_slip
+
+    def test_salary_slip_defaults(self):
+        """Verify default tax fields on new salary slip"""
+        slip = self.create_test_salary_slip(with_components=False)
+
+        if hasattr(slip, "tax_calculation_method"):
+            self.assertEqual(slip.tax_calculation_method, "Manual")
+
+        if hasattr(slip, "income_tax_slab"):
+            self.assertIsNone(slip.income_tax_slab)
 
     def test_add_new_component(self):
         """Test adding a new component"""

--- a/payroll_indonesia/payroll_indonesia/tests/test_tax_calculator.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_tax_calculator.py
@@ -113,6 +113,11 @@ class TestTaxCalculator(unittest.TestCase):
                 "gross_pay": gross_pay or self.example_gross,
             }
         )
+        if hasattr(salary_slip, "tax_calculation_method"):
+            salary_slip.tax_calculation_method = "Manual"
+        if hasattr(salary_slip, "income_tax_slab"):
+            salary_slip.income_tax_slab = None
+
         salary_slip.insert(ignore_permissions=True)
         return salary_slip
 

--- a/payroll_indonesia/payroll_indonesia/tests/test_ter_calculator.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_ter_calculator.py
@@ -64,6 +64,12 @@ class TestTERCalculator(unittest.TestCase):
                 "gross_pay": 10000000,  # 10 juta rupiah
             }
         )
+
+        if hasattr(salary_slip, "tax_calculation_method"):
+            salary_slip.tax_calculation_method = "Manual"
+        if hasattr(salary_slip, "income_tax_slab"):
+            salary_slip.income_tax_slab = None
+
         salary_slip.insert(ignore_permissions=True)
         cls.test_salary_slip = salary_slip
 

--- a/payroll_indonesia/payroll_indonesia/tests/test_ytd_utils.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_ytd_utils.py
@@ -86,7 +86,14 @@ class TestYTDCalculations(unittest.TestCase):
                         1 if status == "Submitted" else (2 if status == "Cancelled" else 0)
                     ),
                 }
-            ).insert(ignore_permissions=True)
+            )
+
+            if hasattr(slip, "tax_calculation_method"):
+                slip.tax_calculation_method = "Manual"
+            if hasattr(slip, "income_tax_slab"):
+                slip.income_tax_slab = None
+
+            slip.insert(ignore_permissions=True)
 
             cls.salary_slips.append(slip)
 


### PR DESCRIPTION
## Summary
- ensure salary slip creation sets `tax_calculation_method` to Manual and clears `income_tax_slab`
- apply same logic in tests when constructing salary slips
- validate defaults in salary component tests
- add CHANGELOG entry

## Testing
- `flake8 payroll_indonesia/override/payroll_entry_functions.py payroll_indonesia/payroll_indonesia/tests/test_*py` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_686d551dbcf8832c81b8cd6309abed40