### PR TITLE
Add TER rate template wrapper

### DIFF
--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -161,7 +161,7 @@ jinja = {
         "payroll_indonesia.config.config.get_live_config",
         # Tax calculation methods
         "payroll_indonesia.override.salary_slip.tax_calculator.get_ptkp_value",
-        "payroll_indonesia.payroll_indonesia.utils.get_ter_rate",
+        "payroll_indonesia.payroll_indonesia.utils.get_ter_rate_for_template",
         # BPJS methods
         "payroll_indonesia.override.salary_slip.bpjs_calculator.calculate_components",
         "payroll_indonesia.payroll_indonesia.doctype.bpjs_account_mapping.bpjs_account_mapping.get_mapping_for_company",

--- a/payroll_indonesia/payroll_indonesia/utils.py
+++ b/payroll_indonesia/payroll_indonesia/utils.py
@@ -36,6 +36,7 @@ __all__ = [
     "update_employee_tax_summary",
     "get_ptkp_to_ter_mapping",
     "get_ter_rate",
+    "get_ter_rate_for_template",
     "get_status_pajak",
 ]
 
@@ -554,6 +555,17 @@ def get_ter_rate(category: str, annual_income: float) -> float:
         return flt(settings.get_ter_rate(category, annual_income)) / 100.0
     except Exception:
         return flt(get_ter_rate_from_child(category, annual_income)) / 100.0
+
+
+def get_ter_rate_for_template(category: str, monthly_income: float) -> float:
+    """Return TER rate for use in Jinja templates."""
+    try:
+        from payroll_indonesia.override.salary_slip import tax_calculator
+
+        return flt(tax_calculator.get_ter_rate(category, monthly_income))
+    except Exception as e:
+        logger.exception(f"Error getting TER rate for template: {e}")
+        return 0.0
 
 
 @safe_execute(default_value=0.0)


### PR DESCRIPTION
## Summary
- add get_ter_rate_for_template helper
- expose new helper via __all__
- use wrapper in hooks for Jinja

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_686e57836fb4832cb333a8231dd9fb83