### PR TITLE
Fix December detection in payroll calculation

### DIFF
--- a/payroll_indonesia/override/payroll_entry_functions.py
+++ b/payroll_indonesia/override/payroll_entry_functions.py
@@ -37,17 +37,26 @@ def is_december_calculation(entry: Any) -> bool:
     """
     Determine if payroll should use December calculation logic.
 
+    The function checks an explicit ``is_december_override`` flag on the
+    :class:`Payroll Entry` and falls back to detecting whether the payroll period
+    ends in December.
+
     Args:
         entry: Payroll Entry document
 
     Returns:
-        bool: True if December or override flag is set
+        bool: ``True`` if December or the override flag is set
     """
     # Check explicit override flag
-    if getattr(entry, "is_december_run", 0):
+    if getattr(entry, "is_december_override", 0):
         return True
 
-    # Check if month is December
+    # Check if the payroll period ends in December
+    if hasattr(entry, "end_date") and entry.end_date:
+        end_date = getdate(entry.end_date)
+        return end_date.month == 12
+
+    # Fallback to start_date if end_date isn't available
     if hasattr(entry, "start_date") and entry.start_date:
         start_date = getdate(entry.start_date)
         return start_date.month == 12


### PR DESCRIPTION
## Summary
- fix `is_december_calculation` to use `is_december_override` flag
- detect December via the end date

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68719deab2bc832cbb1ed891f3f252cb