### PR TITLE
Update December detection logic

### DIFF
--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -77,7 +77,15 @@ class IndonesiaPayrollSalarySlip(SalarySlip):
         If is_december_override is set, this activates the annual tax correction
         logic by setting bypass_annual_detection and updating the payroll note.
         """
-        if hasattr(self, "is_december_override") and cint(self.is_december_override) == 1:
+        end_date = getattr(self, "end_date", None)
+        is_december_month = False
+        if end_date:
+            try:
+                is_december_month = getdate(end_date).month == 12
+            except Exception:
+                logger.warning(f"Invalid end_date for slip {getattr(self, 'name', '')}: {end_date}")
+
+        if is_december_month or cint(getattr(self, "is_december_override", 0)) == 1:
             # Activate bypass to ensure annual correction is applied
             self.bypass_annual_detection = 1
             

--- a/payroll_indonesia/override/salary_slip_functions.py
+++ b/payroll_indonesia/override/salary_slip_functions.py
@@ -151,7 +151,15 @@ def update_component_amount(doc: Document, method: Optional[str] = None) -> None
             doc.is_using_ter = 0
             
             # Check if this is a December slip with annual correction
-            if getattr(doc, "is_december_override", 0):
+            end_date = getattr(doc, "end_date", None)
+            is_december_month = False
+            if end_date:
+                try:
+                    is_december_month = getdate(end_date).month == 12
+                except Exception:
+                    logger.warning(f"Invalid end_date for slip {doc.name}: {end_date}")
+
+            if is_december_month or getattr(doc, "is_december_override", 0):
                 # December annual correction calculation
                 result = calculate_december_pph(doc)
                 


### PR DESCRIPTION
## Summary
- handle December override based on slip's end_date
- prefer end_date in monthly calculations
- ensure newline at EOF

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68719df8ba40832c855b4124ad33dfef