### PR TITLE
Fix comment typo in constants

### DIFF
--- a/payroll_indonesia/constants.py
+++ b/payroll_indonesia/constants.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2025, PT. Innovasi Terbaik Bangsa and contributors
 # For license information, please see license.txt
-# Last modified: 2025-05-11 10:08:25 by dannyaudianlanjutkan
+# Last modified: 2025-05-11 10:08:25 by dannyaudian
 
 """
 Constants for Payroll Indonesia module.


### PR DESCRIPTION
## Summary
- fix typo in header comment inside `constants.py`
- verify other header comments for typos

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68727acc61cc832cb6e5f11269bde25b