### PR TITLE
Implement after_submit hook

### DIFF
--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -42,6 +42,7 @@ doc_events = {
         "validate": "payroll_indonesia.override.salary_slip_functions.update_component_amount",
         "after_insert": "payroll_indonesia.override.salary_slip_functions.initialize_fields",
         "on_submit": "payroll_indonesia.override.salary_slip_functions.salary_slip_post_submit",
+        "after_submit": "payroll_indonesia.override.salary_slip_functions.after_submit",
         "on_cancel": "payroll_indonesia.override.salary_slip_functions.enqueue_tax_summary_update",
     },
     "BPJS Account Mapping": {

--- a/payroll_indonesia/payroll_indonesia/tests/test_salary_slip_after_submit.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_salary_slip_after_submit.py
@@ -1,0 +1,27 @@
+import sys
+import types
+import pytest
+
+pytest.importorskip("frappe")
+
+
+def test_after_submit_updates_tax_summary(monkeypatch):
+    frappe = types.ModuleType("frappe")
+    frappe.utils = types.ModuleType("frappe.utils")
+    frappe.utils.flt = float
+    frappe.utils.cint = int
+    sys.modules["frappe"] = frappe
+    sys.modules["frappe.utils"] = frappe.utils
+
+    import importlib
+    ssf = importlib.import_module("payroll_indonesia.override.salary_slip_functions")
+
+    called = {}
+    monkeypatch.setattr(ssf, "utils", types.SimpleNamespace(update_employee_tax_summary=lambda emp, slip: called.setdefault("args", (emp, slip))))
+    monkeypatch.setattr(ssf, "logger", types.SimpleNamespace(debug=lambda *a, **k: None, exception=lambda *a, **k: None))
+
+    doc = types.SimpleNamespace(employee="EMP-1", name="SS-001", calculate_indonesia_tax=1, flags=types.SimpleNamespace())
+
+    ssf.after_submit(doc)
+
+    assert called.get("args") == ("EMP-1", "SS-001")


### PR DESCRIPTION
## Summary
- add utilities import and logger to salary slip functions
- implement `after_submit` to update employee tax summary
- register new doc event in hooks
- test that after_submit calls update_employee_tax_summary

## Testing
- `./scripts/install_dependencies.sh` *(fails: Could not install frappe)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875b8d65874832c8af42189d5fc289c