### PR TITLE
Fix Biaya Jabatan formula

### DIFF
--- a/payroll_indonesia/override/salary_slip/tax_calculator.py
+++ b/payroll_indonesia/override/salary_slip/tax_calculator.py
@@ -850,7 +850,10 @@ def calculate_monthly_pph_progressive(slip: Any) -> Tuple[float, Dict[str, Any]]
         
         # Deduct Biaya Jabatan (occupation allowance)
         # 5% of gross income, maximum 6,000,000 per year
-        biaya_jabatan = min(annual_taxable * BIAYA_JABATAN_PERCENT, BIAYA_JABATAN_MAX)
+        biaya_jabatan = min(
+            annual_taxable * BIAYA_JABATAN_PERCENT / 100,
+            BIAYA_JABATAN_MAX * MONTHS_PER_YEAR,
+        )
         
         # Deduct tax deductible components (annualized)
         tax_deductions = tax_components["total"]["pengurang_netto"] * MONTHS_PER_YEAR
@@ -970,7 +973,10 @@ def calculate_december_pph(slip: Any) -> Tuple[float, Dict[str, Any]]:
 
         # Deduct Biaya Jabatan (occupation allowance)
         # 5% of gross income, maximum 6,000,000 per year
-        biaya_jabatan = min(annual_taxable * BIAYA_JABATAN_PERCENT, BIAYA_JABATAN_MAX)
+        biaya_jabatan = min(
+            annual_taxable * BIAYA_JABATAN_PERCENT / 100,
+            BIAYA_JABATAN_MAX * MONTHS_PER_YEAR,
+        )
         
         # Deduct annual tax deductions (YTD BPJS + current month tax deductions)
         current_deductions = tax_components["total"]["pengurang_netto"]

--- a/payroll_indonesia/payroll_indonesia/tests/test_biaya_jabatan.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_biaya_jabatan.py
@@ -1,0 +1,44 @@
+import sys
+import types
+import importlib
+import pytest
+
+pytest.importorskip("frappe")
+
+
+def test_biaya_jabatan_calculation(monkeypatch):
+    # Import target module dynamically
+    tax_mod = importlib.import_module(
+        "payroll_indonesia.override.salary_slip.tax_calculator"
+    )
+
+    # Stub helper functions used by calculation
+    monkeypatch.setattr(tax_mod, "get_tax_status", lambda slip: slip.status_pajak)
+    monkeypatch.setattr(tax_mod, "get_ptkp_value", lambda status: 0)
+    monkeypatch.setattr(tax_mod, "calculate_progressive_tax", lambda pkp: (0, []))
+    monkeypatch.setattr(
+        tax_mod,
+        "categorize_components_by_tax_effect",
+        lambda slip: {
+            "total": {
+                "penambah_bruto": slip.gross_pay,
+                "pengurang_netto": 0,
+                "natura_objek": 0,
+            }
+        },
+    )
+
+    slip = types.SimpleNamespace(gross_pay=10000000, status_pajak="TK0")
+
+    tax, details = tax_mod.calculate_monthly_pph_progressive(slip)
+
+    expected = min(
+        details["annual_taxable"] * tax_mod.BIAYA_JABATAN_PERCENT / 100,
+        tax_mod.BIAYA_JABATAN_MAX * tax_mod.MONTHS_PER_YEAR,
+    )
+    assert details["biaya_jabatan"] == expected
+
+    # Check cap when income is high
+    slip_high = types.SimpleNamespace(gross_pay=30000000, status_pajak="TK0")
+    tax, details = tax_mod.calculate_monthly_pph_progressive(slip_high)
+    assert details["biaya_jabatan"] == tax_mod.BIAYA_JABATAN_MAX * tax_mod.MONTHS_PER_YEAR


### PR DESCRIPTION
## Summary
- fix calculation of `biaya_jabatan` in progressive and December tax logic
- add regression test verifying annualized deduction and cap

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875c3b55d7c832c9a2f5930aa946a4e