### PR TITLE
Fix TER field naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## [Unreleased]
 ### Added
 - Salary slip creation now forces `tax_calculation_method` to "Manual" and clears `income_tax_slab`.
+- Renamed `use_ter_method` field on Payroll Entry to `ter_method_enabled`.

--- a/payroll_indonesia/fixtures/custom_fields.json
+++ b/payroll_indonesia/fixtures/custom_fields.json
@@ -239,12 +239,12 @@
   {
     "doctype": "Custom Field",
     "dt": "Payroll Entry",
-    "fieldname": "use_ter_method",
+    "fieldname": "ter_method_enabled",
     "fieldtype": "Check",
     "insert_after": "naming_series",
     "label": "Use TER Method",
     "module": "Payroll Indonesia",
-    "name": "Payroll Entry-use_ter_method",
+    "name": "Payroll Entry-ter_method_enabled",
     "default": "0"
   },
   {
@@ -252,7 +252,7 @@
     "dt": "Payroll Entry",
     "fieldname": "is_december_override",
     "fieldtype": "Check",
-    "insert_after": "use_ter_method",
+    "insert_after": "ter_method_enabled",
     "label": "Run as December/Desember Override",
     "module": "Payroll Indonesia",
     "name": "Payroll Entry-is_december_override",

--- a/payroll_indonesia/override/payroll_entry.py
+++ b/payroll_indonesia/override/payroll_entry.py
@@ -187,14 +187,21 @@ class CustomPayrollEntry(Document):
             value: Value to set (default True)
         """
         try:
-            self.use_ter_method = 1 if value else 0
+            self.ter_method_enabled = 1 if value else 0
             
             # If document is already saved, update in database
             if self.name and not self.is_new():
-                frappe.db.set_value("Payroll Entry", self.name, "use_ter_method", self.use_ter_method)
+                frappe.db.set_value(
+                    "Payroll Entry",
+                    self.name,
+                    "ter_method_enabled",
+                    self.ter_method_enabled,
+                )
                 frappe.db.commit()
-            
-            logger.debug(f"Set use_ter_method={self.use_ter_method} for payroll entry {getattr(self, 'name', 'unknown')}")
+
+            logger.debug(
+                f"Set ter_method_enabled={self.ter_method_enabled} for payroll entry {getattr(self, 'name', 'unknown')}"
+            )
         
         except Exception as e:
             logger.exception(f"Error setting TER method: {str(e)}")
@@ -321,10 +328,15 @@ class PayrollEntryIndonesia:
                 return
             
             # Get settings to propagate
+            tax_method = (
+                "TER"
+                if cint(getattr(self.doc, "ter_method_enabled", 0)) == 1
+                else getattr(self.doc, "tax_method", "Progressive")
+            )
             settings = {
                 "calculate_indonesia_tax": 1,
-                "tax_method": getattr(self.doc, "tax_method", "Progressive"),
-                "is_december_override": cint(getattr(self.doc, "is_december_override", 0))
+                "tax_method": tax_method,
+                "is_december_override": cint(getattr(self.doc, "is_december_override", 0)),
             }
             
             # Propagate to each slip


### PR DESCRIPTION
## Summary
- rename Payroll Entry field `use_ter_method` to `ter_method_enabled`
- set/get `ter_method_enabled` in `CustomPayrollEntry.use_ter_method`
- check `ter_method_enabled` when copying tax settings to slips
- update changelog

## Testing
- `./scripts/install_dependencies.sh` *(fails: Could not find a version that satisfies the requirement frappe>=15.0.0)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687635315310832cb431eafa5f9098d5