### PR TITLE
Fix December tax precedence

### DIFF
--- a/payroll_indonesia/override/salary_slip/controller.py
+++ b/payroll_indonesia/override/salary_slip/controller.py
@@ -455,17 +455,20 @@ def process_indonesia_taxes(doc: Any) -> float:
             )
             return 0.0
 
-        # Get tax method
-        tax_method = getattr(doc, "tax_method", "Progressive")
-        logger.debug(f"Using tax method: {tax_method}")
-
-        # Calculate based on method
-        if tax_method == "TER":
-            tax_amount, details = calculate_monthly_pph_with_ter(doc)
-        elif is_december_calculation(doc):
+        # Check for December override first
+        if is_december_calculation(doc):
+            logger.debug("Using December tax calculation")
             tax_amount, details = calculate_december_pph(doc)
         else:
-            tax_amount, details = calculate_monthly_pph_progressive(doc)
+            # Get tax method
+            tax_method = getattr(doc, "tax_method", "Progressive")
+            logger.debug(f"Using tax method: {tax_method}")
+
+            # Calculate based on method
+            if tax_method == "TER":
+                tax_amount, details = calculate_monthly_pph_with_ter(doc)
+            else:
+                tax_amount, details = calculate_monthly_pph_progressive(doc)
 
         # Update slip with calculation details
         update_slip_with_tax_details(doc, details)

--- a/payroll_indonesia/payroll_indonesia/tests/test_tax_calculator.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_tax_calculator.py
@@ -294,6 +294,24 @@ class TestTaxCalculator(unittest.TestCase):
 
         self.assertEqual(flt(details.get("correction_amount"), 2), flt(expected_correction, 2))
 
+    def test_december_override_ter_uses_progressive(self):
+        """Slip with TER method and December override should use progressive logic"""
+        employee = self.test_employees["complete"]
+
+        salary_slip = self.create_salary_slip(employee)
+        salary_slip.tax_method = "TER"
+        salary_slip.is_december_override = 1
+        salary_slip.posting_date = getdate("2025-12-10")
+        salary_slip.save(ignore_permissions=True)
+
+        result = calculate_tax_components(salary_slip, employee)
+        self.assertTrue(result.get("success"))
+
+        # Should not use TER fields
+        self.assertEqual(flt(salary_slip.ter_rate, 2), 0)
+        self.assertTrue(getattr(salary_slip, "tax_brackets_json", ""))
+        self.assertTrue(getattr(salary_slip, "koreksi_pph21", 0) >= 0)
+
 
 def run_tax_calculator_tests():
     """Run tax calculator tests"""


### PR DESCRIPTION
## Summary
- prioritize December tax check before tax method
- test December override with TER

## Testing
- `pytest -k test_december_override_ter_uses_progressive -q` *(fails: 14 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687635262eec832ca0916bd96d791b8a