### PR TITLE
Enhance December PPh21 fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Payroll Indonesia by PT. Innovasi Terbaik Bangsa is an ERPNext v15 payroll modul
 * **🛠 ERPNext HR Integration:** Works with ERPNext's standard HR module (Salary Component, Salary Structure, Salary Slip, Payroll Entry) and adds custom DocTypes such as Employee Tax Summary and Payroll Indonesia Settings. No separate HRMS app is required.
 * **💡 Automated BPJS Calculation:** Automatic calculation of BPJS Kesehatan (Healthcare) and Ketenagakerjaan (Employment Security - JHT, JP, JKK, JKM) complying with the latest regulations, with validation for contribution percentages and maximum salary limits.
 * **📊 PPh 21 Calculation:** Supports TER (PMK 168/2023) and monthly progressive methods, special calculations for December for annual SPT reporting, including validation for PTKP and Tax Bracket settings.
+* **📆 December Corrections:** When no Employee Tax Summary is found, December tax calculation now sums any `koreksi_pph21` values from submitted Salary Slips.
 * **⚡ Memory Optimization:** Efficient YTD and YTM calculations, comprehensive error handling to manage RAM usage, and complete integration with dedicated calculation modules.
 
 ## 📦 Installation


### PR DESCRIPTION
## Summary
- include koreksi_pph21 totals when calculating December correction without an Employee Tax Summary
- expose `tax_correction` in `get_ytd_totals`
- document the behaviour in the README
- test fallback logic using prior submitted slips

## Testing
- `pytest -q` *(fails: 14 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68763ab5f3b8832ca33f35a725f0db0d