### PR TITLE
Check row tax_effect_type before default

### DIFF
--- a/payroll_indonesia/override/salary_slip/salary_utils.py
+++ b/payroll_indonesia/override/salary_slip/salary_utils.py
@@ -249,7 +249,10 @@ def categorize_components_by_tax_effect(slip: Any) -> Dict[str, Dict[str, float]
                 if amount <= 0:
                     continue
                 
-                tax_effect = get_component_tax_effect(component, "Earning")
+                tax_effect = (
+                    getattr(earning, "tax_effect_type", None)
+                    or get_component_tax_effect(component, "Earning")
+                )
                 
                 # Default to non-taxable if not defined
                 if not tax_effect:
@@ -276,7 +279,10 @@ def categorize_components_by_tax_effect(slip: Any) -> Dict[str, Dict[str, float]
                 if component == "PPh 21":
                     continue
                 
-                tax_effect = get_component_tax_effect(component, "Deduction")
+                tax_effect = (
+                    getattr(deduction, "tax_effect_type", None)
+                    or get_component_tax_effect(component, "Deduction")
+                )
                 
                 # Default to non-deductible if not defined
                 if not tax_effect:

--- a/payroll_indonesia/override/salary_slip/tax_calculator.py
+++ b/payroll_indonesia/override/salary_slip/tax_calculator.py
@@ -532,7 +532,10 @@ def categorize_components_by_tax_effect(slip: Any) -> Dict[str, Dict[str, float]
                     continue
 
                 # Get tax effect for this earning
-                tax_effect = get_component_tax_effect(component_name, "Earning")
+                tax_effect = (
+                    getattr(earning, "tax_effect_type", None)
+                    or get_component_tax_effect(component_name, "Earning")
+                )
 
                 # Categorize based on tax effect
                 if tax_effect == "Penambah Bruto/Objek Pajak":
@@ -566,7 +569,10 @@ def categorize_components_by_tax_effect(slip: Any) -> Dict[str, Dict[str, float]
                     continue
 
                 # Get tax effect for this deduction
-                tax_effect = get_component_tax_effect(component_name, "Deduction")
+                tax_effect = (
+                    getattr(deduction, "tax_effect_type", None)
+                    or get_component_tax_effect(component_name, "Deduction")
+                )
 
                 # Categorize based on tax effect
                 if tax_effect == "Penambah Bruto/Objek Pajak":


### PR DESCRIPTION
## Summary
- detect salary component tax effect from the row first
- fall back to `get_component_tax_effect` if row field is empty

## Testing
- `pytest -q` *(tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68765ca7fcb8832cb94b8334bfdc725d