### PR TITLE
Add salary slip timesheet wrapper

### DIFF
--- a/payroll_indonesia/override/salary_slip/make_salary_slip_from_timesheet.py
+++ b/payroll_indonesia/override/salary_slip/make_salary_slip_from_timesheet.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+"""Wrapper for make_salary_slip_from_timesheet."""
+
+from hrms.payroll.doctype.salary_slip.salary_slip import (
+    make_salary_slip_from_timesheet as _make_salary_slip_from_timesheet,
+)
+
+
+def make_salary_slip_from_timesheet(*args, **kwargs):
+    """Proxy to HRMS `make_salary_slip_from_timesheet`."""
+    return _make_salary_slip_from_timesheet(*args, **kwargs)


### PR DESCRIPTION
## Summary
- create a wrapper to call `hrms.payroll.doctype.salary_slip.salary_slip.make_salary_slip_from_timesheet`
- keep hooks override path pointing to new function

## Testing
- `pytest -q`
- `flake8 payroll_indonesia/override/salary_slip/make_salary_slip_from_timesheet.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687754339b40832c86adb3952ac9c505