### PR TITLE
Resolve license mismatch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 dannyaudian
+Copyright (c) 2025 PT. Innovasi Terbaik Bangsa and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
 
 Actively developed and deployed across diverse production environments. For issue reporting and feature requests, visit our [GitHub Repository](https://github.com/dannyaudian/payroll_indonesia).
 
+## 📝 License
+
+This project is released under the **MIT License**. See the [LICENSE](LICENSE) file for full details.
+
 ---
 
 ✨ **Last updated:** July 2025

--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -12,7 +12,7 @@ app_publisher = "PT. Innovasi Terbaik Bangsa"
 app_description = "Payroll module for Indonesian companies with local regulations"
 app_email = "danny.a.pratama@cao-group.co.id"
 app_icon = "octicon octicon-file-directory"
-app_license = "GPL-3"
+app_license = "MIT"
 app_version = "0.1.0"
 required_apps = ["erpnext", "hrms"]
 


### PR DESCRIPTION
## Summary
- fix app_license constant to use MIT
- update license copyright owner
- mention MIT license in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68775a723b10832ca4ce573337db44d4