### PR TITLE
Implement automatic company account creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ can run outside of a bench instance.
 ```bash
 bench --site your_site.local migrate
 ```
+   This step now also creates default expense accounts such as **Beban Gaji Pokok**,
+   **Beban Tunjangan Makan**, and **Beban Tunjangan Transport** for each company.
 
 2. **⚙ Manual Setup After Installation:**
 

--- a/payroll_indonesia/setup/setup_module.py
+++ b/payroll_indonesia/setup/setup_module.py
@@ -54,19 +54,19 @@ def setup_accounts() -> bool:
     try:
         from payroll_indonesia.fixtures.setup import setup_company_accounts
 
-        # Get all companies
-        companies = frappe.get_all("Company", pluck="name")
-        for company in companies:
-            setup_company_accounts(None, company=company)
-        logger.info("Company accounts setup completed")
-
-        logger.info("Setting up Payroll Indonesia tax infrastructure")
-
         # Load defaults from configuration
         defaults = _load_defaults()
         if not defaults:
             logger.warning("Could not load defaults from configuration")
             return False
+
+        # Get all companies and create GL accounts
+        companies = frappe.get_all("Company", pluck="name")
+        for company in companies:
+            setup_company_accounts(company=company, config=defaults)
+        logger.info("Company accounts setup completed")
+
+        logger.info("Setting up Payroll Indonesia tax infrastructure")
 
         # Import specialized setup functions
         from payroll_indonesia.utilities.tax_slab import setup_income_tax_slab


### PR DESCRIPTION
## Summary
- ensure accounts for each company are created on migration
- add hook helper for creating GL accounts per company
- document automatic account creation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687784b7b4bc832ca7a4d6f29affddec