### PR TITLE
Remove obsolete employer BPJS flag

### DIFF
--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -52,3 +52,9 @@ Supplier templates seeded during setup. Currently contains a single `bpjs` suppl
 
 ## tipe_karyawan
 List of employee types inserted into the **Tipe Karyawan Entry** child table (`tipe_karyawan`).
+
+## tax_component_config
+Maps salary components to tax effect categories used by the tax calculator. The
+`bpjs_employee_as_deduction` flag controls whether the employee portion of BPJS
+reduces taxable income. The earlier `bpjs_employer_as_income` option has been
+removed as employer contributions are always treated as non-taxable.

--- a/payroll_indonesia/config/defaults.json
+++ b/payroll_indonesia/config/defaults.json
@@ -1180,7 +1180,6 @@
                 "Fasilitas Kendaraan"
             ]
         },
-        "bpjs_employer_as_income": true,
         "bpjs_employee_as_deduction": true
     }
 }

--- a/payroll_indonesia/payroll_indonesia/tests/test_config_bpjs_flag.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_config_bpjs_flag.py
@@ -1,0 +1,12 @@
+import pytest
+
+frappe = pytest.importorskip("frappe")
+from payroll_indonesia.config import config
+
+
+def test_bpjs_employer_flag_removed():
+    config.reset_config_cache()
+    cfg = config.get_config()
+    tax_cfg = cfg.get("tax_component_config", {})
+    assert "bpjs_employer_as_income" not in tax_cfg
+    assert tax_cfg.get("bpjs_employee_as_deduction") is True


### PR DESCRIPTION
## Summary
- drop unused `bpjs_employer_as_income` from defaults
- document `tax_component_config` section
- check config no longer exposes the flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687784d45448832c898a1848e10f183d