### PR TITLE
Fix on_update creation timestamp checks

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/bpjs_account_mapping.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/bpjs_account_mapping.py
@@ -315,4 +315,10 @@ class BPJSAccountMapping(Document):
 
     def on_update(self):
         """Clear cache after update"""
+        original_creation = frappe.db.get_value(self.doctype, self.name, "creation")
         frappe.cache().delete_value(f"bpjs_mapping_{self.company}")
+        if original_creation and self.creation != original_creation:
+            logger.warning(
+                f"Creation timestamp mismatch for {self.name}. Resetting to original value"
+            )
+            self.creation = original_creation

--- a/payroll_indonesia/payroll_indonesia/doctype/bpjs_payment_summary_detail/bpjs_payment_summary_detail.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/bpjs_payment_summary_detail/bpjs_payment_summary_detail.py
@@ -57,7 +57,13 @@ class BPJSPaymentSummaryDetail(Document):
 
         Calls parent service to recalculate totals.
         """
+        original_creation = frappe.db.get_value(self.doctype, self.name, "creation")
         self._trigger_parent_recalculation()
+        if original_creation and self.creation != original_creation:
+            logger.warning(
+                f"Creation timestamp mismatch for {self.name}. Resetting to original value"
+            )
+            self.creation = original_creation
 
     def _trigger_parent_recalculation(self) -> None:
         """

--- a/payroll_indonesia/payroll_indonesia/doctype/employee_monthly_tax_detail/employee_monthly_tax_detail.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/employee_monthly_tax_detail/employee_monthly_tax_detail.py
@@ -103,7 +103,13 @@ class EmployeeMonthlyTaxDetail(Document):
     
     def on_update(self):
         """Trigger parent document update when this document changes."""
+        original_creation = frappe.db.get_value(self.doctype, self.name, "creation")
         self.update_parent()
+        if original_creation and self.creation != original_creation:
+            logger.warning(
+                f"Creation timestamp mismatch for {self.name}. Resetting to original value"
+            )
+            self.creation = original_creation
 
     def get_tax_components_from_json(self):
         """Extract tax components from JSON field."""

--- a/payroll_indonesia/payroll_indonesia/doctype/employee_tax_summary/employee_tax_summary.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/employee_tax_summary/employee_tax_summary.py
@@ -493,6 +493,7 @@ class EmployeeTaxSummary(Document):
     def on_update(self) -> None:
         """Perform actions after document is updated."""
         try:
+            original_creation = frappe.db.get_value(self.doctype, self.name, "creation")
             # Update title if not set
             if not self.title:
                 self._set_title()
@@ -533,6 +534,12 @@ class EmployeeTaxSummary(Document):
                         break
                 
                 self.db_set("december_override_note", december_note, update_modified=False)
+
+            if original_creation and self.creation != original_creation:
+                logger.warning(
+                    f"Creation timestamp mismatch for {self.name}. Resetting to original value"
+                )
+                self.creation = original_creation
                 
         except Exception as e:
             logger.error(f"Failed in on_update: {frappe.get_traceback()}")

--- a/payroll_indonesia/payroll_indonesia/doctype/payroll_indonesia_settings/payroll_indonesia_settings.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/payroll_indonesia_settings/payroll_indonesia_settings.py
@@ -33,8 +33,14 @@ def on_update(doc, method=None):
         doc: The document instance being updated
         method: The method that triggered this hook (unused)
     """
+    original_creation = frappe.db.get_value(doc.doctype, doc.name, "creation")
     if doc.sync_to_defaults:
         utils.write_json_file_if_enabled(doc)
+    if original_creation and doc.creation != original_creation:
+        logger.warning(
+            f"Creation timestamp mismatch for {doc.name}. Resetting to original value"
+        )
+        doc.creation = original_creation
 
 
 class PayrollIndonesiaSettings(Document):
@@ -80,8 +86,15 @@ class PayrollIndonesiaSettings(Document):
 
         Syncs settings to defaults.json if enabled.
         """
+        original_creation = frappe.db.get_value(self.doctype, self.name, "creation")
         if self.sync_to_defaults:
             utils.write_json_file_if_enabled(self)
+
+        if original_creation and self.creation != original_creation:
+            logger.warning(
+                f"Creation timestamp mismatch for {self.name}. Resetting to original value"
+            )
+            self.creation = original_creation
 
     def _validate_tax_settings(self) -> None:
         """


### PR DESCRIPTION
## Summary
- ensure original `creation` timestamp is restored if modified in on_update hooks
- apply check across EmployeeOverride and core doctypes

## Testing
- `pytest -q`
- `./scripts/install_dependencies.sh` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68779b009a00832ca1648f40ef29a5a2