### PR TITLE
Fix GL account defaults for unmapped components

### DIFF
--- a/payroll_indonesia/config/gl_account_mapper.py
+++ b/payroll_indonesia/config/gl_account_mapper.py
@@ -99,7 +99,7 @@ def map_gl_account(company: str, account_key: str, category: str) -> str:
         # Check if account exists, create if needed
         if not frappe.db.exists("Account", formatted_account_name):
             # Get account type and root type from config
-            account_type = account_info.get("account_type", "Expense")
+            account_type = account_info.get("account_type", "Expense Account")
             root_type = account_info.get("root_type", "Expense")
 
             # Determine default parent
@@ -188,7 +188,7 @@ def get_gl_account_for_salary_component(company: str, salary_component: str) -> 
 
         # Create account if needed and return suffixed name
         return get_or_create_account(
-            company, base_name, "Expense", "Expense"
+            company, base_name, "Expense Account", "Expense"
         )
     
     # Get the account key and category from the mapping


### PR DESCRIPTION
## Summary
- set fallback account type to **Expense Account** when mapping accounts
- create Expense Account-type accounts for unmapped salary components

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687880c58880832c96efd1d1ab2be953