### PR TITLE
Expose create_default_mapping and add scheduler test

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/__init__.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/__init__.py
@@ -1,1 +1,4 @@
-# This file marks the BPJS Account Mapping doctype directory as a Python package
+# Explicit exports for easier imports
+from .bpjs_account_mapping import create_default_mapping
+
+__all__ = ["create_default_mapping"]

--- a/payroll_indonesia/payroll_indonesia/tests/test_scheduler_bpjs_mapping.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_scheduler_bpjs_mapping.py
@@ -1,0 +1,36 @@
+import unittest
+import pytest
+
+frappe = pytest.importorskip("frappe")
+
+from payroll_indonesia.payroll_indonesia.doctype.bpjs_account_mapping import create_default_mapping
+
+
+class TestSchedulerBPJSMapping(unittest.TestCase):
+    def setUp(self):
+        self.company = frappe.get_doc(
+            {
+                "doctype": "Company",
+                "company_name": "Scheduler Mapping Co",
+                "abbr": "SMC",
+                "default_currency": "IDR",
+                "country": "Indonesia",
+                "domain": "Services",
+            }
+        )
+        if not frappe.db.exists("Company", self.company.name):
+            self.company.insert(ignore_permissions=True)
+
+    def tearDown(self):
+        frappe.db.rollback()
+
+    def test_create_default_mapping_callable(self):
+        if frappe.db.exists("BPJS Account Mapping", {"company": self.company.name}):
+            frappe.db.delete("BPJS Account Mapping", {"company": self.company.name})
+
+        create_default_mapping(self.company.name)
+
+        self.assertTrue(
+            frappe.db.exists("BPJS Account Mapping", {"company": self.company.name})
+        )
+


### PR DESCRIPTION
## Summary
- export `create_default_mapping` from BPJS Account Mapping package
- test scheduler can call Doctype mapping helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878b0ffc474832cbefca8a16a0a6485