### PR TITLE
Add guidance on parent account candidate fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,12 @@ setup.after_install()
 
 * Use the **BPJS Account Mapping** DocType to set up BPJS Employee and Employer accounts.
 * Ensure account configurations align with the company's Chart of Accounts structure.
-* If your Chart of Accounts uses localized names, set **Parent Account Candidates Expense**
-  and **Parent Account Candidates Liability** in Payroll Indonesia Settings. Separate multiple
-  candidates with commas or new lines.
+
+### 🗂 Parent Account Candidates
+
+* Set **Parent Account Candidates (Expense)** and **Parent Account Candidates (Liability)** if your Chart of Accounts uses non‑standard names.
+* These fields accept comma‑separated lists and are consulted when creating GL accounts such as **"Hutang PPh 21"**.
+* See [docs/defaults.md](docs/defaults.md#root-account-names) for further details.
 
 ### 📐 PPh 21 Settings
 

--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -42,6 +42,16 @@ names, adjust `parent_account_candidates_expense` and
 to your actual top‑level expense and liability accounts. You can specify more
 than one name separated by commas or new lines.
 
+Example for Indonesian account groups:
+
+```
+parent_account_candidates_expense: Beban
+parent_account_candidates_liability: Kewajiban
+```
+
+With these values the module can create accounts like "Hutang PPh 21" under the
+"Kewajiban" group if no matching English parent exists.
+
 ## settings
 Miscellaneous behaviour flags such as `sync_to_defaults` and parent account candidates. Stored on **Payroll Indonesia Settings**.
 


### PR DESCRIPTION
## Summary
- explain usage of Parent Account Candidate fields in README
- link to docs/defaults.md for more information
- show example of localized account names in docs/defaults.md

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b2fe60a4832c9c102ac4dc820a83