### PR TITLE
Update BPJS account mapping fields

### DIFF
--- a/payroll_indonesia/config/gl_account_mapper.py
+++ b/payroll_indonesia/config/gl_account_mapper.py
@@ -21,6 +21,23 @@ from payroll_indonesia.payroll_indonesia.utils import (
 # Setup logger
 logger = logging.getLogger(__name__)
 
+# Field names used in BPJSAccountMapping DocType
+BPJS_ACCOUNT_FIELDS = [
+    "kesehatan_employee_account",
+    "jht_employee_account",
+    "jp_employee_account",
+    "kesehatan_employer_debit_account",
+    "kesehatan_employer_credit_account",
+    "jht_employer_debit_account",
+    "jht_employer_credit_account",
+    "jp_employer_debit_account",
+    "jp_employer_credit_account",
+    "jkk_employer_debit_account",
+    "jkk_employer_credit_account",
+    "jkm_employer_debit_account",
+    "jkm_employer_credit_account",
+]
+
 
 def map_gl_account(company: str, account_key: str, category: str) -> str:
     """
@@ -150,23 +167,21 @@ def _get_bpjs_account_mapping(company: str, salary_component: str) -> str:
 
         row = mapping[0]
         component = salary_component.lower()
+        field_name = ""
 
         if "kesehatan" in component:
-            if "employer" in component:
-                return row.get("kesehatan_employer_debit_account", "")
-            return row.get("kesehatan_employee_account", "")
-        if "jht" in component:
-            if "employer" in component:
-                return row.get("jht_employer_debit_account", "")
-            return row.get("jht_employee_account", "")
-        if "jp" in component:
-            if "employer" in component:
-                return row.get("jp_employer_debit_account", "")
-            return row.get("jp_employee_account", "")
-        if "jkk" in component:
-            return row.get("jkk_employer_debit_account", "")
-        if "jkm" in component:
-            return row.get("jkm_employer_debit_account", "")
+            field_name = "kesehatan_employer_debit_account" if "employer" in component else "kesehatan_employee_account"
+        elif "jht" in component:
+            field_name = "jht_employer_debit_account" if "employer" in component else "jht_employee_account"
+        elif "jp" in component:
+            field_name = "jp_employer_debit_account" if "employer" in component else "jp_employee_account"
+        elif "jkk" in component:
+            field_name = "jkk_employer_debit_account"
+        elif "jkm" in component:
+            field_name = "jkm_employer_debit_account"
+
+        if field_name and field_name in BPJS_ACCOUNT_FIELDS:
+            return row.get(field_name, "")
 
         return ""
     except Exception as e:  # pragma: no cover - defensive

--- a/payroll_indonesia/utilities/fix_doctype_structure.py
+++ b/payroll_indonesia/utilities/fix_doctype_structure.py
@@ -450,25 +450,31 @@ def fix_bpjs_account_mapping():
                 "reqd": 1,
                 "insert_after": "mapping_name",
             },
-            "employee_expense_account": {
-                "fieldtype": "Link",
-                "label": "Employee Expense Account",
-                "options": "Account",
-                "insert_after": "company",
-            },
-            "employer_expense_account": {
-                "fieldtype": "Link",
-                "label": "Employer Expense Account",
-                "options": "Account",
-                "insert_after": "employee_expense_account",
-            },
-            "payable_account": {
-                "fieldtype": "Link",
-                "label": "Payable Account",
-                "options": "Account",
-                "insert_after": "employer_expense_account",
-            },
         }
+
+        for idx, field in enumerate(
+            [
+                "kesehatan_employee_account",
+                "jht_employee_account",
+                "jp_employee_account",
+                "kesehatan_employer_debit_account",
+                "kesehatan_employer_credit_account",
+                "jht_employer_debit_account",
+                "jht_employer_credit_account",
+                "jp_employer_debit_account",
+                "jp_employer_credit_account",
+                "jkk_employer_debit_account",
+                "jkk_employer_credit_account",
+                "jkm_employer_debit_account",
+                "jkm_employer_credit_account",
+            ]
+        ):
+            required_fields[field] = {
+                "fieldtype": "Link",
+                "label": frappe.unscrub(field).replace("account", "Account").title(),
+                "options": "Account",
+                "insert_after": list(required_fields.keys())[-1],
+            }
 
         # Check if fields exist already
         docfields = frappe.get_meta("BPJS Account Mapping").fields
@@ -583,9 +589,19 @@ def diagnose_doctype_structure():
             # Check required fields
             required_fields = [
                 "company",
-                "employee_expense_account",
-                "employer_expense_account",
-                "payable_account",
+                "kesehatan_employee_account",
+                "jht_employee_account",
+                "jp_employee_account",
+                "kesehatan_employer_debit_account",
+                "kesehatan_employer_credit_account",
+                "jht_employer_debit_account",
+                "jht_employer_credit_account",
+                "jp_employer_debit_account",
+                "jp_employer_credit_account",
+                "jkk_employer_debit_account",
+                "jkk_employer_credit_account",
+                "jkm_employer_debit_account",
+                "jkm_employer_credit_account",
             ]
             docfields = frappe.get_meta("BPJS Account Mapping").fields
             existing_fields = [df.fieldname for df in docfields]


### PR DESCRIPTION
## Summary
- use new account field names for BPJS Account Mapping
- validate and return all BPJS accounts
- adjust GL account mapper for new mapping fields
- update Doctype structure fixer for new fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b4abc2184832caa5e067d8c2374e2