### PR TITLE
Fix BPJS Account Mapping hooks

### DIFF
--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -45,8 +45,8 @@ doc_events = {
         "after_submit": "payroll_indonesia.override.salary_slip_functions.after_submit",
     },
     "BPJS Account Mapping": {
-        "validate": "payroll_indonesia.payroll_indonesia.doctype.bpjs_account_mapping.bpjs_account_mapping.validate",
-        "on_update": "payroll_indonesia.payroll_indonesia.doctype.bpjs_account_mapping.bpjs_account_mapping.on_update",
+        "validate": "payroll_indonesia.payroll_indonesia.doctype.bpjs_account_mapping.bpjs_account_mapping.BPJSAccountMapping.validate",
+        "on_update": "payroll_indonesia.payroll_indonesia.doctype.bpjs_account_mapping.bpjs_account_mapping.BPJSAccountMapping.on_update",
     },
     "BPJS Payment Summary": {
         "validate": "payroll_indonesia.payroll_indonesia.doctype.bpjs_payment_summary.bpjs_payment_summary.validate",

--- a/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/bpjs_account_mapping.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/bpjs_account_mapping.py
@@ -10,8 +10,6 @@ from payroll_indonesia.frappe_helpers import logger
 
 __all__ = [
     "BPJSAccountMapping",
-    "validate",
-    "on_update",
     "get_mapping_for_company",
     "create_default_mapping",
     "get_bpjs_accounts",
@@ -36,36 +34,8 @@ ACCOUNT_FIELDS = [
 ]
 
 # ---------------------------------------------------------------------------
-# Module level functions
+# Helper Functions
 # ---------------------------------------------------------------------------
-
-
-def validate(doc, method=None):
-    """
-    Global validation hook for BPJS Account Mapping document.
-    Called by background jobs and setup processes.
-
-    Args:
-        doc: The document being validated
-        method: The method that triggered this hook (optional)
-    """
-    doc.validate()
-
-
-def on_update(doc, method=None):
-    """
-    Global on_update hook for BPJS Account Mapping document.
-    Called by hooks after document is updated.
-
-    Args:
-        doc: The document being updated
-        method: The method that triggered this hook (optional)
-    """
-    doc.on_update()
-
-    # Optionally sync to settings
-    sync_to_settings(doc)
-
 
 def sync_to_settings(doc, method=None):
     """
@@ -323,3 +293,5 @@ class BPJSAccountMapping(Document):
                 f"Creation timestamp mismatch for {self.name}. Resetting to original value"
             )
             self.creation = original_creation
+        # keep settings in sync after update
+        sync_to_settings(self)


### PR DESCRIPTION
## Summary
- remove unused module level hooks from bpjs_account_mapping
- update hooks to call class methods directly
- keep sync_to_settings triggered via `on_update`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b4c84128c832cb0f6f837ca74bd8a