### PR TITLE
Handle errors in setup helpers

### DIFF
--- a/payroll_indonesia/fixtures/setup.py
+++ b/payroll_indonesia/fixtures/setup.py
@@ -164,9 +164,6 @@ def after_sync():
         return
 
     try:
-        # Begin transaction
-        frappe.db.begin()
-
         # Load defaults from settings_migration
         defaults = _load_defaults()
         if not defaults:
@@ -198,15 +195,12 @@ def after_sync():
         except Exception as e:
             logger.error(f"Error during full install: {str(e)}")
 
-        # Commit changes
-        frappe.db.commit()
         logger.info("after_sync process completed successfully")
 
         # Mark as run for idempotence
         after_sync.already_run = True
 
     except Exception as e:
-        frappe.db.rollback()
         logger.error(f"Error during after_sync: {str(e)}", exc_info=True)
         frappe.log_error(
             f"Error during after_sync: {str(e)}\n\n{frappe.get_traceback()}",


### PR DESCRIPTION
## Summary
- raise exceptions from seeding helpers instead of returning False
- wrap `migrate_all_settings` in a DB transaction
- adjust CLI and sync hooks to rely on new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b4ea5119c832c8a3a63c00a5586a0