### PR TITLE
Clarify migration hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,21 @@ bench --site your_site.local migrate
    This step now also creates default expense accounts such as **Beban Gaji Pokok**,
    **Beban Tunjangan Makan**, and **Beban Tunjangan Transport** for each company.
 
-2. **🔄 After Sync:** During `bench migrate` the app's `after_sync` hook automatically
-   populates **Payroll Indonesia Settings** and ensures required fixtures exist. You
-   can rerun this step manually with:
+2. **🔄 After Sync (Installation Tasks):** During `bench migrate` the app's
+   `after_sync` hook runs installation routines such as creating default
+   accounts, suppliers, and salary structures. You can rerun this step
+   manually with:
 
 ```bash
 bench --site your_site.local execute payroll_indonesia.fixtures.setup.after_sync
 ```
 
-3. **⚙ Manual Setup After Installation:**
+3. **🛠 After Migrate (Data Updates):** Frappe triggers the `after_migrate`
+   hook after `after_sync`. This step migrates existing
+   **Payroll Indonesia Settings** and ensures each company has a BPJS Account
+   Mapping.
+
+4. **⚙ Manual Setup After Installation:**
 
 ```bash
 bench --site your_site.local execute payroll_indonesia.fixtures.setup.after_install

--- a/payroll_indonesia/fixtures/setup.py
+++ b/payroll_indonesia/fixtures/setup.py
@@ -147,57 +147,19 @@ def after_install():
 
 
 def after_sync():
-    """
-    Hook after app sync. Ensures Payroll Indonesia Settings exists and is populated.
-
-    This function ensures all configuration data from defaults.json is properly
-    migrated to Payroll Indonesia Settings and its child tables.
-
-    Returns:
-        None
-    """
+    """Run installation routines after Frappe sync."""
     logger.info("Starting after_sync process for Payroll Indonesia")
 
-    # Check if function already ran in this session (idempotent)
     if hasattr(after_sync, "already_run") and after_sync.already_run:
         logger.info("after_sync already ran in this session, skipping")
         return
 
     try:
-        # Load defaults from settings_migration
-        defaults = _load_defaults()
-        if not defaults:
-            logger.warning("Failed to load configuration from defaults.json")
-            return
-
-        # Run migration with zero args - it will automatically load the settings doc
-        logger.info("Running migrate_all_settings()")
-        results = migrate_all_settings()
-
-        # Log summary of results
-        if results:
-            success_count = sum(1 for result in results.values() if result)
-            total_count = len(results)
-            logger.info(
-                f"Settings migration results: {success_count}/{total_count} sections updated"
-            )
-
-            # Log individual results for debugging
-            for section, success in results.items():
-                status = "updated" if success else "skipped"
-                logger.debug(f"Section '{section}': {status}")
-        else:
-            logger.warning("migrate_all_settings() returned no results")
-
-        # Run simplified installation to ensure components exist
-        try:
-            _run_full_install(defaults, skip_existing=True)
-        except Exception as e:
-            logger.error(f"Error during full install: {str(e)}")
+        # Run full installation but skip existing records so it's idempotent
+        _run_full_install(skip_existing=True)
 
         logger.info("after_sync process completed successfully")
 
-        # Mark as run for idempotence
         after_sync.already_run = True
 
     except Exception as e:

--- a/payroll_indonesia/setup/setup_module.py
+++ b/payroll_indonesia/setup/setup_module.py
@@ -267,30 +267,11 @@ def ensure_bpjs_account_mappings() -> bool:
 
 
 def after_migrate():
-    """Run after migrate.
-
-    Ensures salary components receive GL account mappings and the default
-    salary structure is created when running ``bench migrate``.
-    """
+    """Run post-migration data updates."""
     try:
-        # Ensure settings document exists first
         ensure_settings_doctype_exists()
-
-        # Setup fixtures that may have been skipped
-        setup_accounts()
+        migrate_all_settings()
         ensure_bpjs_account_mappings()
-
-        # Map GL accounts to salary components and create default salary structure
-        from payroll_indonesia.fixtures.setup import (
-            setup_default_salary_structure,
-            setup_salary_components,
-        )
-
-        defaults = _load_defaults()
-        if defaults:
-            setup_salary_components(defaults)
-
-        setup_default_salary_structure()
 
         logger.info("Post-migration setup completed successfully")
     except Exception as e:


### PR DESCRIPTION
## Summary
- simplify `after_sync` to only run installation routines
- limit `after_migrate` to migration steps
- document hook order and responsibilities

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b508bd4e4832cb2916bbf7bca37e8