### PR TITLE
Remove redundant BPJS mapping validation steps

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/utils.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/utils.py
@@ -58,8 +58,6 @@ def validate_mapping(doc, method=None):
     # Call the instance methods
     if not getattr(doc, "flags", {}).get("ignore_validate"):
         doc.validate_duplicate_mapping()
-        doc.validate_account_types()
-        doc.setup_missing_accounts()
 
     # Clean up flag
     doc._validated = False


### PR DESCRIPTION
## Summary
- remove unnecessary account validation calls from the BPJS mapping wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b54ca973c832cbc2258a993bdc24e