### PR TITLE
Handle open transactions during setup

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/bpjs_account_mapping.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/bpjs_account_mapping.py
@@ -129,7 +129,7 @@ def get_mapping_for_company(company=None):
 
 
 @frappe.whitelist()
-def create_default_mapping(company):
+def create_default_mapping(company, transaction_open=False):
     """
     Create a default BPJS Account Mapping with blank accounts
 
@@ -160,7 +160,8 @@ def create_default_mapping(company):
 
         # Insert with ignore_permissions
         mapping.insert(ignore_permissions=True)
-        frappe.db.commit()
+        if not transaction_open:
+            frappe.db.commit()
 
         # Clear cache for the company
         frappe.cache().delete_value(f"bpjs_mapping_{company}")
@@ -168,7 +169,8 @@ def create_default_mapping(company):
         return mapping.name
 
     except Exception as e:
-        frappe.db.rollback()
+        if not transaction_open:
+            frappe.db.rollback()
         frappe.log_error(
             f"Error creating default BPJS account mapping for {company}: {str(e)}\n\n"
             f"Traceback: {frappe.get_traceback()}",

--- a/payroll_indonesia/setup/setup_module.py
+++ b/payroll_indonesia/setup/setup_module.py
@@ -246,7 +246,7 @@ def ensure_settings_doctype_exists() -> bool:
         return False
 
 
-def ensure_bpjs_account_mappings() -> bool:
+def ensure_bpjs_account_mappings(transaction_open=False) -> bool:
     """Ensure each company has a BPJS Account Mapping."""
     try:
         from payroll_indonesia.payroll_indonesia.doctype.bpjs_account_mapping import (
@@ -257,7 +257,7 @@ def ensure_bpjs_account_mappings() -> bool:
         companies = frappe.get_all("Company", pluck="name")
         for company in companies:
             if not frappe.db.exists("BPJS Account Mapping", {"company": company}):
-                create_default_mapping(company)
+                create_default_mapping(company, transaction_open=transaction_open)
                 created = True
 
         return created


### PR DESCRIPTION
## Summary
- prevent nested transactions in installation helpers
- allow setup helpers to skip DB begin/commit when a transaction is already open
- ensure BPJS account mapping creation supports existing transactions

## Testing
- `pytest payroll_indonesia/payroll_indonesia/tests/test_bpjs_account_mapping.py -q`
- `pytest payroll_indonesia/payroll_indonesia/tests/test_after_migrate.py -q`
- `pytest payroll_indonesia/payroll_indonesia/tests/test_scheduler_bpjs_mapping.py -q`
- `pytest payroll_indonesia/payroll_indonesia/tests/test_income_tax_slab_setup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687b57350260832cad85f85092c3e51f