### PR TITLE
Remove commit/rollback from create_default_mapping

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/bpjs_account_mapping.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/bpjs_account_mapping.py
@@ -129,7 +129,7 @@ def get_mapping_for_company(company=None):
 
 
 @frappe.whitelist()
-def create_default_mapping(company, transaction_open=False):
+def create_default_mapping(company):
     """
     Create a default BPJS Account Mapping with blank accounts
 
@@ -160,8 +160,6 @@ def create_default_mapping(company, transaction_open=False):
 
         # Insert with ignore_permissions
         mapping.insert(ignore_permissions=True)
-        if not transaction_open:
-            frappe.db.commit()
 
         # Clear cache for the company
         frappe.cache().delete_value(f"bpjs_mapping_{company}")
@@ -169,8 +167,6 @@ def create_default_mapping(company, transaction_open=False):
         return mapping.name
 
     except Exception as e:
-        if not transaction_open:
-            frappe.db.rollback()
         frappe.log_error(
             f"Error creating default BPJS account mapping for {company}: {str(e)}\n\n"
             f"Traceback: {frappe.get_traceback()}",

--- a/payroll_indonesia/payroll_indonesia/tests/test_bpjs_account_mapping.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_bpjs_account_mapping.py
@@ -43,6 +43,7 @@ class TestBPJSAccountMapping(unittest.TestCase):
             frappe.db.delete("BPJS Account Mapping", {"company": self.company.name})
 
         name = create_default_mapping(self.company.name)
+        frappe.db.commit()
         self.assertTrue(frappe.db.exists("BPJS Account Mapping", name))
 
         doc = frappe.get_doc("BPJS Account Mapping", name)
@@ -53,6 +54,7 @@ class TestBPJSAccountMapping(unittest.TestCase):
     def test_get_mapping_for_company_includes_fields(self):
         if not frappe.db.exists("BPJS Account Mapping", {"company": self.company.name}):
             create_default_mapping(self.company.name)
+            frappe.db.commit()
 
         mapping_dict = get_mapping_for_company(self.company.name)
         for field in ACCOUNT_FIELDS:
@@ -73,6 +75,7 @@ class TestBPJSAccountMapping(unittest.TestCase):
             )
         else:
             name = create_default_mapping(self.company.name)
+            frappe.db.commit()
             mapping = frappe.get_doc("BPJS Account Mapping", name)
 
         mapping.kesehatan_employee_account = wrong_acc

--- a/payroll_indonesia/payroll_indonesia/tests/test_scheduler_bpjs_mapping.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_scheduler_bpjs_mapping.py
@@ -29,6 +29,7 @@ class TestSchedulerBPJSMapping(unittest.TestCase):
             frappe.db.delete("BPJS Account Mapping", {"company": self.company.name})
 
         create_default_mapping(self.company.name)
+        frappe.db.commit()
 
         self.assertTrue(
             frappe.db.exists("BPJS Account Mapping", {"company": self.company.name})

--- a/payroll_indonesia/setup/setup_module.py
+++ b/payroll_indonesia/setup/setup_module.py
@@ -257,7 +257,7 @@ def ensure_bpjs_account_mappings(transaction_open=False) -> bool:
         companies = frappe.get_all("Company", pluck="name")
         for company in companies:
             if not frappe.db.exists("BPJS Account Mapping", {"company": company}):
-                create_default_mapping(company, transaction_open=transaction_open)
+                create_default_mapping(company)
                 created = True
 
         return created


### PR DESCRIPTION
## Summary
- stop handling DB transactions inside `create_default_mapping`
- update setup code to call the function without `transaction_open`
- adjust tests to commit explicitly after using the helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b596de4c4832c994f36fae863cbb4