### PR TITLE
Fix mapping completeness calculation

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/bpjs_account_mapping.js
+++ b/payroll_indonesia/payroll_indonesia/doctype/bpjs_account_mapping/bpjs_account_mapping.js
@@ -96,12 +96,19 @@ async function validate_create_journal_entry(frm) {
 // Update status indicator based on mapping completeness
 function update_mapping_status(frm) {
     const required_accounts = [
-        'kesehatan_employee_account', 
+        'kesehatan_employee_account',
         'kesehatan_employer_debit_account',
         'kesehatan_employer_credit_account',
         'jht_employee_account',
         'jht_employer_debit_account',
-        'jht_employer_credit_account'
+        'jht_employer_credit_account',
+        'jp_employee_account',
+        'jp_employer_debit_account',
+        'jp_employer_credit_account',
+        'jkk_employer_debit_account',
+        'jkk_employer_credit_account',
+        'jkm_employer_debit_account',
+        'jkm_employer_credit_account'
     ];
     
     let total_filled = 0;


### PR DESCRIPTION
## Summary
- include all account fields when computing BPJS Account Mapping completion

## Testing
- `flake8` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_687b5f6bf484832cac3ac9518f2b3cc8