### PR TITLE
Map new salary components to GL accounts

### DIFF
--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -50,6 +50,31 @@ jkm_employer_debit_account
 jkm_employer_credit_account
 ```
 
+### Expense accounts
+
+The `expense_accounts` object defines GL accounts for common salary components:
+
+```
+beban_gaji_pokok
+beban_tunjangan_makan
+beban_tunjangan_transport
+beban_insentif
+beban_bonus
+beban_tunjangan_jabatan
+beban_tunjangan_lembur
+beban_natura
+beban_fasilitas_kendaraan
+```
+
+### Payable accounts
+
+Default liability accounts created during setup:
+
+```
+hutang_pph21
+hutang_kasbon
+```
+
 ### Root account names
 
 The default configuration assumes your site uses the standard English root

--- a/payroll_indonesia/config/defaults.json
+++ b/payroll_indonesia/config/defaults.json
@@ -837,12 +837,37 @@
                 "account_name": "Beban Bonus",
                 "account_type": "Direct Expense",
                 "root_type": "Expense"
+            },
+            "beban_tunjangan_jabatan": {
+                "account_name": "Beban Tunjangan Jabatan",
+                "account_type": "Direct Expense",
+                "root_type": "Expense"
+            },
+            "beban_tunjangan_lembur": {
+                "account_name": "Beban Tunjangan Lembur",
+                "account_type": "Direct Expense",
+                "root_type": "Expense"
+            },
+            "beban_natura": {
+                "account_name": "Beban Natura",
+                "account_type": "Direct Expense",
+                "root_type": "Expense"
+            },
+            "beban_fasilitas_kendaraan": {
+                "account_name": "Beban Fasilitas Kendaraan",
+                "account_type": "Direct Expense",
+                "root_type": "Expense"
             }
         },
         "payable_accounts": {
             "hutang_pph21": {
                 "account_name": "Hutang PPh 21",
                 "account_type": "Tax",
+                "root_type": "Liability"
+            },
+            "hutang_kasbon": {
+                "account_name": "Hutang Kasbon",
+                "account_type": "Payable",
                 "root_type": "Liability"
             }
         },

--- a/payroll_indonesia/config/gl_account_mapper.py
+++ b/payroll_indonesia/config/gl_account_mapper.py
@@ -224,8 +224,13 @@ def get_gl_account_for_salary_component(company: str, salary_component: str) -> 
         "Tunjangan Transport": ("beban_tunjangan_transport", "expense_accounts"),
         "Insentif": ("beban_insentif", "expense_accounts"),
         "Bonus": ("beban_bonus", "expense_accounts"),
+        "Tunjangan Jabatan": ("beban_tunjangan_jabatan", "expense_accounts"),
+        "Tunjangan Lembur": ("beban_tunjangan_lembur", "expense_accounts"),
+        "Uang Makan": ("beban_natura", "expense_accounts"),
+        "Fasilitas Kendaraan": ("beban_fasilitas_kendaraan", "expense_accounts"),
         # Deductions
         "PPh 21": ("hutang_pph21", "payable_accounts"),
+        "Potongan Kasbon": ("hutang_kasbon", "payable_accounts"),
     }
 
     # Get the component type (Earning or Deduction) to determine account category

--- a/payroll_indonesia/fixtures/setup.py
+++ b/payroll_indonesia/fixtures/setup.py
@@ -869,7 +869,15 @@ def setup_company_accounts(doc=None, method=None, company=None, config=None):
 
         # Create expense accounts for standard salary components
         gl_accounts = config.get("gl_accounts", {}).get("expense_accounts", {})
-        for key in ["beban_gaji_pokok", "beban_tunjangan_makan", "beban_tunjangan_transport"]:
+        for key in [
+            "beban_gaji_pokok",
+            "beban_tunjangan_makan",
+            "beban_tunjangan_transport",
+            "beban_tunjangan_jabatan",
+            "beban_tunjangan_lembur",
+            "beban_natura",
+            "beban_fasilitas_kendaraan",
+        ]:
             if key in gl_accounts:
                 map_gl_account(company_name, key, "expense_accounts")
 


### PR DESCRIPTION
## Summary
- extend default expense and payable accounts
- map new components in `gl_account_mapper`
- create GL accounts for these components during setup
- document new account keys in defaults reference

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b6449e5a4832c931a67b1da707459