### PR TITLE
Move bpjs mapping util to new module

### DIFF
--- a/payroll_indonesia/fixtures/setup.py
+++ b/payroll_indonesia/fixtures/setup.py
@@ -26,7 +26,7 @@ from payroll_indonesia.config.gl_account_mapper import (
     _map_component_to_account,
 )
 from payroll_indonesia.setup.settings_migration import migrate_all_settings, _load_defaults
-from payroll_indonesia.setup.setup_module import ensure_bpjs_account_mappings
+from payroll_indonesia.setup.bpjs import ensure_bpjs_account_mappings
 
 
 # Define exported functions

--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -56,7 +56,7 @@ doc_events = {
     "Company": {
         "after_insert": [
             "payroll_indonesia.fixtures.setup.setup_company_accounts",
-            "payroll_indonesia.setup.setup_module.ensure_bpjs_account_mappings",
+            "payroll_indonesia.setup.bpjs.ensure_bpjs_account_mappings",
         ],
         "on_update": "payroll_indonesia.fixtures.setup.setup_company_accounts",
     },

--- a/payroll_indonesia/setup/bpjs.py
+++ b/payroll_indonesia/setup/bpjs.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""BPJS setup utilities for Payroll Indonesia."""
+
+import frappe
+
+from payroll_indonesia.frappe_helpers import get_logger
+
+logger = get_logger("setup")
+
+
+def ensure_bpjs_account_mappings(transaction_open: bool = False) -> bool:
+    """Ensure each company has a BPJS Account Mapping."""
+    try:
+        from payroll_indonesia.payroll_indonesia.doctype.bpjs_account_mapping import (
+            create_default_mapping,
+        )
+
+        created = False
+        companies = frappe.get_all("Company", pluck="name")
+        for company in companies:
+            if not frappe.db.exists("BPJS Account Mapping", {"company": company}):
+                create_default_mapping(company)
+                created = True
+
+        return created
+    except Exception as e:
+        logger.error(f"Error ensuring BPJS Account Mappings: {str(e)}")
+        return False

--- a/payroll_indonesia/setup/setup_module.py
+++ b/payroll_indonesia/setup/setup_module.py
@@ -246,24 +246,6 @@ def ensure_settings_doctype_exists() -> bool:
         return False
 
 
-def ensure_bpjs_account_mappings(transaction_open=False) -> bool:
-    """Ensure each company has a BPJS Account Mapping."""
-    try:
-        from payroll_indonesia.payroll_indonesia.doctype.bpjs_account_mapping import (
-            create_default_mapping,
-        )
-
-        created = False
-        companies = frappe.get_all("Company", pluck="name")
-        for company in companies:
-            if not frappe.db.exists("BPJS Account Mapping", {"company": company}):
-                create_default_mapping(company)
-                created = True
-
-        return created
-    except Exception as e:
-        logger.error(f"Error ensuring BPJS Account Mappings: {str(e)}")
-        return False
 
 
 def after_migrate():


### PR DESCRIPTION
## Summary
- add `bpjs.py` module with `ensure_bpjs_account_mappings`
- update imports in fixtures and hooks
- delete duplicate function from `setup_module`

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b6bd34044832c8fd8960a6345d846