### PR TITLE
Handle transactions in BPJS mapping setup

### DIFF
--- a/payroll_indonesia/setup/bpjs.py
+++ b/payroll_indonesia/setup/bpjs.py
@@ -9,7 +9,21 @@ logger = get_logger("setup")
 
 
 def ensure_bpjs_account_mappings(transaction_open: bool = False) -> bool:
-    """Ensure each company has a BPJS Account Mapping."""
+    """Ensure each company has a BPJS Account Mapping.
+
+    Args:
+        transaction_open: ``True`` if the caller has already opened a database
+            transaction. When ``False`` this function will manage its own
+            transaction and commit or roll back on failure.
+
+    Returns:
+        bool: ``True`` if a mapping was created for at least one company,
+        ``False`` otherwise or if an error occurred.
+    """
+
+    if not transaction_open:
+        frappe.db.begin()
+
     try:
         from payroll_indonesia.payroll_indonesia.doctype.bpjs_account_mapping import (
             create_default_mapping,
@@ -22,7 +36,12 @@ def ensure_bpjs_account_mappings(transaction_open: bool = False) -> bool:
                 create_default_mapping(company)
                 created = True
 
+        if not transaction_open:
+            frappe.db.commit()
+
         return created
     except Exception as e:
+        if not transaction_open:
+            frappe.db.rollback()
         logger.error(f"Error ensuring BPJS Account Mappings: {str(e)}")
         return False


### PR DESCRIPTION
## Summary
- manage transactions within `ensure_bpjs_account_mappings`
- call `ensure_bpjs_account_mappings` with `transaction_open=True` from `_run_full_install`

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b777ead90832ca4a4874f7e0ada92