### PR TITLE
Remove unused tax_payable assignment

### DIFF
--- a/payroll_indonesia/fixtures/setup.py
+++ b/payroll_indonesia/fixtures/setup.py
@@ -327,7 +327,7 @@ def setup_accounts(config=None, specific_company=None, *, skip_existing=False):
             expense_parent = create_parent_expense_account(company.name)
 
             # Create tax payable account
-            tax_payable = get_or_create_account(
+            get_or_create_account(
                 company=company.name,
                 account_name="PPh 21 Payable",
                 account_type="Tax",


### PR DESCRIPTION
## Summary
- remove unused `tax_payable` variable assignment in setup fixture

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b7e0c1e14832c816a30e033e98665