### PR TITLE
Update default parent account candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ setup.after_install()
 
 ### 🗂 Parent Account Candidates
 
-* Set **Parent Account Candidates (Expense)** and **Parent Account Candidates (Liability)** if your Chart of Accounts uses non‑standard names.
+* The defaults include Indonesian group names **Beban** and **Kewajiban** in addition to their English counterparts.
+* Set **Parent Account Candidates (Expense)** and **Parent Account Candidates (Liability)** if your Chart of Accounts uses other names.
 * These fields accept comma‑separated lists and are consulted when creating GL accounts such as **"Hutang PPh 21"**.
 * See [docs/defaults.md](docs/defaults.md#root-account-names) for further details.
 

--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -79,7 +79,9 @@ hutang_kasbon
 
 The default configuration assumes your site uses the standard English root
 groups created by ERPNext, such as **"Assets - {abbr}"**, **"Liabilities -
-{abbr}"** and **"Expenses - {abbr}"**. If your Chart of Accounts uses localized
+{abbr}"** and **"Expenses - {abbr}"**. The bundled defaults also include the
+Indonesian group names **"Beban"** and **"Kewajiban"** so that common charts of
+accounts work out of the box. If your Chart of Accounts uses other localized
 names, adjust `parent_account_candidates_expense` and
 `parent_account_candidates_liability` in **Payroll Indonesia Settings** to point
 to your actual top‑level expense and liability accounts. You can specify more

--- a/payroll_indonesia/config/defaults.json
+++ b/payroll_indonesia/config/defaults.json
@@ -928,8 +928,8 @@
     },
     "settings": {
         "sync_to_defaults": false,
-        "parent_account_candidates_expense": "Direct Expenses",
-        "parent_account_candidates_liability": "Duties and Taxes"
+        "parent_account_candidates_expense": "Direct Expenses, Beban",
+        "parent_account_candidates_liability": "Duties and Taxes, Kewajiban"
     },
     "bpjs_settings": {
         "validation_rules": {

--- a/payroll_indonesia/payroll_indonesia/utils.py
+++ b/payroll_indonesia/payroll_indonesia/utils.py
@@ -326,9 +326,19 @@ def get_default_parent_candidates(root_type: str) -> list:
         list: List of potential parent account names
     """
     if root_type == "Liability":
-        return ["Duties and Taxes", "Current Liabilities", "Accounts Payable"]
+        return [
+            "Kewajiban",
+            "Duties and Taxes",
+            "Current Liabilities",
+            "Accounts Payable",
+        ]
     elif root_type == "Expense":
-        return ["Direct Expenses", "Indirect Expenses", "Expenses"]
+        return [
+            "Beban",
+            "Direct Expenses",
+            "Indirect Expenses",
+            "Expenses",
+        ]
     elif root_type == "Income":
         return ["Income", "Direct Income", "Indirect Income"]
     elif root_type == "Asset":


### PR DESCRIPTION
## Summary
- add Indonesian defaults in `get_default_parent_candidates`
- update defaults.json with localized account names
- document new defaults in docs and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b97563d88832c9196dc15269d8c65