### PR TITLE
Ensure salary component mappings on company setup

### DIFF
--- a/payroll_indonesia/fixtures/setup.py
+++ b/payroll_indonesia/fixtures/setup.py
@@ -924,6 +924,16 @@ def setup_company_accounts(
             if key in gl_accounts:
                 map_gl_account(company_name, key, "expense_accounts")
 
+        # Map salary components to their GL accounts for this company
+        salary_components_cfg = config.get("salary_components", {})
+        component_names = [c.get("name") for c in salary_components_cfg.get("earnings", [])]
+        component_names += [c.get("name") for c in salary_components_cfg.get("deductions", [])]
+
+        for component_name in filter(None, component_names):
+            account_name = get_gl_account_for_salary_component(company_name, component_name)
+            if account_name:
+                _map_component_to_account(component_name, company_name, account_name)
+
         logger.info(f"[PAYROLL] GL accounts created for: {company_name}")
         return True
     except Exception as e:

--- a/payroll_indonesia/payroll_indonesia/tests/test_setup_company_accounts.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_setup_company_accounts.py
@@ -18,9 +18,16 @@ class TestSetupCompanyAccounts(unittest.TestCase):
         config = get_default_config()
         expected_keys = list(config.get("gl_accounts", {}).get("expense_accounts", {}).keys())
 
+        salary_components = [c["name"] for c in config.get("salary_components", {}).get("earnings", [])]
+        salary_components += [c["name"] for c in config.get("salary_components", {}).get("deductions", [])]
+
         with unittest.mock.patch.object(setup_module, "setup_accounts"), unittest.mock.patch.object(
             setup_module, "map_gl_account"
-        ) as mock_map:
+        ) as mock_map, unittest.mock.patch.object(
+            setup_module, "_map_component_to_account"
+        ) as mock_comp_map, unittest.mock.patch.object(
+            setup_module, "get_gl_account_for_salary_component", return_value="ACC"
+        ):
             result = setup_module.setup_company_accounts(company=self.company, config=config)
 
         self.assertTrue(result)
@@ -28,3 +35,8 @@ class TestSetupCompanyAccounts(unittest.TestCase):
         for key in expected_keys:
             self.assertIn(key, called_keys)
         self.assertEqual(len(called_keys), len(expected_keys))
+
+        called_components = [call.args[0] for call in mock_comp_map.call_args_list]
+        for comp in salary_components:
+            self.assertIn(comp, called_components)
+        self.assertEqual(len(called_components), len(salary_components))


### PR DESCRIPTION
## Summary
- create component-to-account mappings during `setup_company_accounts`
- validate that `_map_component_to_account` is called for each salary component

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bdf748908832cbceb692d567141a4