### PR TITLE
Map English salary components

### DIFF
--- a/payroll_indonesia/config/gl_account_mapper.py
+++ b/payroll_indonesia/config/gl_account_mapper.py
@@ -228,6 +228,15 @@ def get_gl_account_for_salary_component(company: str, salary_component: str) -> 
         "Tunjangan Lembur": ("beban_tunjangan_lembur", "expense_accounts"),
         "Uang Makan": ("beban_natura", "expense_accounts"),
         "Fasilitas Kendaraan": ("beban_fasilitas_kendaraan", "expense_accounts"),
+        # English equivalents
+        "Basic Salary": ("beban_gaji_pokok", "expense_accounts"),
+        "Meal Allowance": ("beban_tunjangan_makan", "expense_accounts"),
+        "Transport Allowance": ("beban_tunjangan_transport", "expense_accounts"),
+        "Incentive": ("beban_insentif", "expense_accounts"),
+        "Position Allowance": ("beban_tunjangan_jabatan", "expense_accounts"),
+        "Overtime Allowance": ("beban_tunjangan_lembur", "expense_accounts"),
+        "Meal Money": ("beban_natura", "expense_accounts"),
+        "Vehicle Facility": ("beban_fasilitas_kendaraan", "expense_accounts"),
         # Deductions
         "PPh 21": ("hutang_pph21", "payable_accounts"),
         "Potongan Kasbon": ("hutang_kasbon", "payable_accounts"),

--- a/payroll_indonesia/payroll_indonesia/tests/test_gl_account_mapper.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_gl_account_mapper.py
@@ -30,3 +30,19 @@ class TestGLAccountMapper(unittest.TestCase):
         gl_account = get_gl_account_for_salary_component(self.company, comp_name)
         self.assertTrue(frappe.db.exists("Account", gl_account))
         self.assertTrue(gl_account.endswith(f" - {self.company_abbr}"))
+
+    def test_english_component_names_map_correctly(self):
+        """Ensure English salary component names map to the same accounts."""
+
+        pairs = [
+            ("Gaji Pokok", "Basic Salary"),
+            ("Tunjangan Makan", "Meal Allowance"),
+            ("Tunjangan Transport", "Transport Allowance"),
+        ]
+
+        for indo, english in pairs:
+            account_indo = get_gl_account_for_salary_component(self.company, indo)
+            account_eng = get_gl_account_for_salary_component(
+                self.company, english
+            )
+            self.assertEqual(account_indo, account_eng)


### PR DESCRIPTION
## Summary
- extend `component_mapping` to recognize English names like `Basic Salary`, `Meal Allowance`, and `Transport Allowance`
- add unit test ensuring English names resolve to same GL account as Indonesian equivalents

## Testing
- `pytest -k gl_account_mapper -q`

------
https://chatgpt.com/codex/tasks/task_e_687c431448ac832c87cce925e50f5069