### PR TITLE
Add helper to fetch expense account from defaults

### DIFF
--- a/payroll_indonesia/payroll_indonesia/tests/test_gl_account_mapper.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_gl_account_mapper.py
@@ -6,6 +6,7 @@ frappe = pytest.importorskip("frappe")
 from payroll_indonesia.config.gl_account_mapper import (
     map_gl_account,
     get_gl_account_for_salary_component,
+    get_expense_account_for_component,
 )
 
 
@@ -46,3 +47,14 @@ class TestGLAccountMapper(unittest.TestCase):
                 self.company, english
             )
             self.assertEqual(account_indo, account_eng)
+
+    def test_get_expense_account_helper(self):
+        self.assertEqual(
+            get_expense_account_for_component("Gaji Pokok"),
+            "Beban Gaji Pokok",
+        )
+        self.assertEqual(
+            get_expense_account_for_component("Basic Salary"),
+            "Beban Gaji Pokok",
+        )
+        self.assertIsNone(get_expense_account_for_component("Unknown"))


### PR DESCRIPTION
## Summary
- lookup expense accounts for salary components via new helper
- test get_expense_account_for_component

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c744db49c832c9805c73f6c4668e6