### PR TITLE
Implement account mapping helper

### DIFF
--- a/payroll_indonesia/payroll_indonesia/tests/test_account_mapping_defaults.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_account_mapping_defaults.py
@@ -1,0 +1,21 @@
+import unittest
+import pytest
+
+pytest.importorskip("frappe")
+
+from payroll_indonesia.payroll_indonesia import utils
+
+
+class TestAccountMappingFromDefaults(unittest.TestCase):
+    def test_bilingual_mapping(self):
+        mapping = utils.get_account_mapping_from_defaults()
+        self.assertEqual(mapping.get("Gaji Pokok"), "Beban Gaji Pokok")
+        self.assertEqual(mapping.get("Basic Salary"), "Beban Gaji Pokok")
+        self.assertEqual(mapping.get("Bonus"), "Beban Bonus")
+        self.assertEqual(mapping.get("Tunjangan Makan"), "Beban Tunjangan Makan")
+        self.assertEqual(mapping.get("Meal Allowance"), "Beban Tunjangan Makan")
+
+    def test_non_bilingual_option(self):
+        mapping = utils.get_account_mapping_from_defaults(bilingual=False)
+        self.assertIn("Gaji Pokok", mapping)
+        self.assertNotIn("Basic Salary", mapping)

--- a/payroll_indonesia/payroll_indonesia/utils.py
+++ b/payroll_indonesia/payroll_indonesia/utils.py
@@ -20,7 +20,11 @@ from typing import Any, Callable, Dict, Optional, TypeVar, cast, Union, List
 import frappe
 from frappe.utils import flt, now, get_site_path, cint
 
-from payroll_indonesia.config.config import get_live_config, get_component_tax_effect
+from payroll_indonesia.config.config import (
+    get_live_config,
+    get_component_tax_effect,
+    get_config as get_default_config,
+)
 from payroll_indonesia.constants import (
     TAX_DEDUCTION_EFFECT,
     TAX_OBJEK_EFFECT,
@@ -41,6 +45,7 @@ __all__ = [
     "get_formatted_currency",
     "write_json_file_if_enabled",
     "cache_get_settings",
+    "get_account_mapping_from_defaults",
     "update_employee_tax_summary",
     "get_ptkp_to_ter_mapping",
     "get_ter_rate",
@@ -660,6 +665,58 @@ def cache_get_settings():
         logger.debug("Retrieved settings from cache")
 
     return settings
+
+
+@lru_cache(maxsize=1)
+def get_account_mapping_from_defaults(bilingual: bool = True) -> Dict[str, str]:
+    """Return salary component to expense account mapping from ``defaults.json``.
+
+    If ``bilingual`` is ``True`` English component names are included as keys so
+    lookups work with either language.
+    """
+    try:
+        config = get_default_config()
+        expense_defs = config.get("gl_accounts", {}).get("expense_accounts", {})
+    except Exception as e:  # pragma: no cover - defensive
+        logger.exception(f"Error loading defaults for account mapping: {e}")
+        return {}
+
+    base_map = {
+        "Gaji Pokok": "beban_gaji_pokok",
+        "Tunjangan Makan": "beban_tunjangan_makan",
+        "Tunjangan Transport": "beban_tunjangan_transport",
+        "Insentif": "beban_insentif",
+        "Bonus": "beban_bonus",
+        "Tunjangan Jabatan": "beban_tunjangan_jabatan",
+        "Tunjangan Lembur": "beban_tunjangan_lembur",
+        "Uang Makan": "beban_natura",
+        "Fasilitas Kendaraan": "beban_fasilitas_kendaraan",
+    }
+
+    english_equiv = {
+        "Basic Salary": "Gaji Pokok",
+        "Meal Allowance": "Tunjangan Makan",
+        "Transport Allowance": "Tunjangan Transport",
+        "Incentive": "Insentif",
+        "Position Allowance": "Tunjangan Jabatan",
+        "Overtime Allowance": "Tunjangan Lembur",
+        "Meal Money": "Uang Makan",
+        "Vehicle Facility": "Fasilitas Kendaraan",
+    }
+
+    mapping: Dict[str, str] = {}
+    for indo_name, key in base_map.items():
+        info = expense_defs.get(key) or {}
+        account_name = info.get("account_name")
+        if not account_name:
+            continue
+        mapping[indo_name] = account_name
+        if bilingual:
+            for eng, indo in english_equiv.items():
+                if indo == indo_name:
+                    mapping[eng] = account_name
+
+    return mapping
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
## Summary
- expand utilities import to include `get_config`
- expose `get_account_mapping_from_defaults` for expense account lookups
- test mapping logic

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c7ce8efb4832c903555241727a57a