### PR TITLE
Refactor GL mapping seed

### DIFF
--- a/payroll_indonesia/config/gl_mapper_core.py
+++ b/payroll_indonesia/config/gl_mapper_core.py
@@ -4,13 +4,14 @@
 """Core helpers for GL account mapping."""
 
 import logging
+import json
 
 import frappe
 
 from payroll_indonesia.constants import BPJS_ACCOUNT_FIELDS
 from payroll_indonesia.config.config import get_config as get_default_config
 from functools import lru_cache
-from typing import Dict
+from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
 
@@ -155,3 +156,56 @@ def get_account_mapping_from_defaults(bilingual: bool = True) -> Dict[str, str]:
                     mapping[eng] = account_name
 
     return mapping
+
+
+def _seed_gl_account_mappings(settings: "frappe.Document", defaults: Dict[str, Any]) -> bool:
+    """Populate GL account mapping fields from defaults.json."""
+    try:
+        changes_made = False
+
+        gl_accounts = defaults.get("gl_accounts", {})
+        bpjs_gl_accounts = defaults.get("bpjs", {}).get("gl_accounts", {})
+
+        mappings = [
+            ("bpjs_account_mapping_json", bpjs_gl_accounts),
+            ("expense_accounts_json", gl_accounts.get("expense_accounts", {})),
+            ("payable_accounts_json", gl_accounts.get("payable_accounts", {})),
+            ("parent_accounts_json", gl_accounts.get("root_account", {})),
+        ]
+
+        for field, value in mappings:
+            if hasattr(settings, field) and not getattr(settings, field) and value:
+                if isinstance(value, (dict, list)):
+                    value = json.dumps(value, indent=2)
+                setattr(settings, field, value)
+                changes_made = True
+
+        settings_cfg = defaults.get("settings", {})
+        candidate_fields = [
+            (
+                "parent_account_candidates_expense",
+                settings_cfg.get("parent_account_candidates_expense"),
+            ),
+            (
+                "parent_account_candidates_liability",
+                settings_cfg.get("parent_account_candidates_liability"),
+            ),
+            (
+                "expense_account_prefix",
+                settings_cfg.get("expense_account_prefix"),
+            ),
+        ]
+
+        for field, value in candidate_fields:
+            if hasattr(settings, field) and not getattr(settings, field) and value is not None:
+                if isinstance(value, (dict, list)):
+                    value = json.dumps(value, indent=2)
+                setattr(settings, field, value)
+                changes_made = True
+
+        return changes_made
+
+    except Exception as e:
+        logger.error(f"Error updating GL account mappings: {str(e)}")
+        raise
+


### PR DESCRIPTION
## Summary
- move `_seed_gl_account_mappings` to `gl_mapper_core`
- import the helper from `settings_migration`
- keep tests green

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687dbb3c144c832ca8e4dcfaee9eb3ce