### PR TITLE
Add persistent install flag

### DIFF
--- a/payroll_indonesia/setup/setup_module.py
+++ b/payroll_indonesia/setup/setup_module.py
@@ -15,6 +15,10 @@ from frappe.utils import now_datetime
 from payroll_indonesia.config.config import doctype_defined
 from payroll_indonesia.setup.settings_migration import migrate_all_settings, _load_defaults
 from payroll_indonesia.frappe_helpers import get_logger
+from payroll_indonesia.utilities.install_flag import (
+    is_installation_complete,
+    mark_installation_complete,
+)
 
 logger = get_logger("setup")
 
@@ -287,9 +291,14 @@ def after_migrate():
         # Core setup that must always run
         ensure_settings_doctype_exists()
 
+        if is_installation_complete():
+            logger.info("Installation flag detected, skipping full install")
+            return
+
         # Delegate to fixtures.setup for the main installation
         from payroll_indonesia.fixtures.setup import perform_essential_setup
         perform_essential_setup()
+        mark_installation_complete()
         logger.info("Post-migration setup completed successfully")
     except Exception as e:
         logger.error(f"Error in after_migrate: {str(e)}")

--- a/payroll_indonesia/utilities/install_flag.py
+++ b/payroll_indonesia/utilities/install_flag.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Persistent install flag helpers for Payroll Indonesia."""
+
+import frappe
+
+FLAG_KEY = "payroll_indonesia_install_complete"
+
+__all__ = [
+    "is_installation_complete",
+    "mark_installation_complete",
+    "clear_installation_flag",
+]
+
+
+def is_installation_complete() -> bool:
+    """Return True if the installation has already run."""
+    try:
+        return bool(frappe.db.get_default(FLAG_KEY))
+    except Exception:
+        return False
+
+
+def mark_installation_complete() -> None:
+    """Mark the installation as completed."""
+    try:
+        frappe.db.set_default(FLAG_KEY, "1")
+    except Exception:
+        pass
+
+
+def clear_installation_flag() -> None:
+    """Remove the persistent installation flag."""
+    try:
+        frappe.db.delete("DefaultValue", {"defkey": FLAG_KEY})
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- ensure Payroll Indonesia setup runs only once using a default value flag
- skip hooks after the flag is set
- add helpers to manage the flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dc15abaf4832caa8e03caceb18828