### PR TITLE
Add relink accounts CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ helpers that resolve the correct BPJS account field and apply account mappings t
 Salary Components. Other modules import these helpers to keep GL logic
 centralized.
 
+## 🔗 Relink Salary Accounts
+
+Reapply default GL accounts to core salary components:
+
+```bash
+bench --site your_site.local execute payroll_indonesia.setup.relink_accounts_cli
+```
+
 ## 🧑‍💻 Contributing
 
 For instructions on setting up Frappe/ERPNext so that `pytest` can run locally, see

--- a/payroll_indonesia/setup/__init__.py
+++ b/payroll_indonesia/setup/__init__.py
@@ -1,1 +1,29 @@
+"""Setup CLI utilities for Payroll Indonesia."""
+
+
+def relink_accounts_cli():
+    """Reapply default GL accounts to salary components.
+
+    Usage:
+        bench --site <site> execute payroll_indonesia.setup.relink_accounts_cli
+    """
+    try:
+        from payroll_indonesia.setup.settings_migration import _load_defaults
+        from payroll_indonesia.fixtures.setup import map_salary_component_to_gl
+        import frappe
+
+        defaults = _load_defaults()
+        companies = frappe.get_all("Company", pluck="name")
+        if not companies:
+            print("No companies found")
+            return
+
+        for company in companies:
+            mapped = map_salary_component_to_gl(company, defaults)
+            if mapped:
+                print(f"{company}: mapped {', '.join(mapped)}")
+            else:
+                print(f"{company}: no mappings applied")
+    except Exception as e:
+        print(f"Error relinking accounts: {e}")
 


### PR DESCRIPTION
## Summary
- add `relink_accounts_cli` util under `payroll_indonesia.setup`
- document how to use the CLI in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687dc43c5e18832cbb3a0a3e1d4e1dd3