### PR TITLE
Check table existence before running setup

### DIFF
--- a/payroll_indonesia/fixtures/setup.py
+++ b/payroll_indonesia/fixtures/setup.py
@@ -190,6 +190,14 @@ def after_install():
         logger.info("Installation flag detected, skipping full install")
         return
 
+    # Ensure required tables exist before running setup
+    if not frappe.db.table_exists("Salary Component"):
+        logger.warning("Skipping after_install: Salary Component table missing")
+        return
+    if not frappe.db.table_exists("Account"):
+        logger.warning("Skipping after_install: Account table missing")
+        return
+
     try:
         _run_full_install(skip_existing=True)
         mark_installation_complete()
@@ -212,6 +220,14 @@ def after_sync():
     if is_installation_complete():
         logger.info("Installation flag detected, skipping full install")
         mark_after_sync_completed()
+        return
+
+    # Ensure required tables exist before running setup
+    if not frappe.db.table_exists("Salary Component"):
+        logger.warning("Skipping after_sync: Salary Component table missing")
+        return
+    if not frappe.db.table_exists("Account"):
+        logger.warning("Skipping after_sync: Account table missing")
         return
 
     try:

--- a/payroll_indonesia/setup/setup_module.py
+++ b/payroll_indonesia/setup/setup_module.py
@@ -288,6 +288,13 @@ def after_migrate():
     try:
         logger.info("========== RUNNING PAYROLL INDONESIA AFTER_MIGRATE ==========")
 
+        if not frappe.db.table_exists("Salary Component"):
+            logger.warning("Skipping after_migrate: Salary Component table missing")
+            return
+        if not frappe.db.table_exists("Account"):
+            logger.warning("Skipping after_migrate: Account table missing")
+            return
+
         # Core setup that must always run
         ensure_settings_doctype_exists()
 


### PR DESCRIPTION
## Summary
- guard setup routines in `after_install`, `after_sync`, and `after_migrate` so they run only when core tables exist

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dc8e3f718832ca9f814521a556b08