### PR TITLE
Refactor company setup

### DIFF
--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -55,11 +55,8 @@ doc_events = {
         "on_cancel": "payroll_indonesia.payroll_indonesia.doctype.bpjs_payment_summary.bpjs_payment_summary.on_cancel",
     },
     "Company": {
-        "after_insert": [
-            "payroll_indonesia.fixtures.setup.setup_company_accounts",
-            "payroll_indonesia.setup.bpjs.ensure_bpjs_account_mappings",
-        ],
-        "on_update": "payroll_indonesia.fixtures.setup.setup_company_accounts",
+        "after_insert": "payroll_indonesia.fixtures.setup.setup_company",
+        "on_update": "payroll_indonesia.fixtures.setup.setup_company",
     },
     "Payment Entry": {
         "on_submit": "payroll_indonesia.payroll_indonesia.doctype.bpjs_payment_summary.payment_hooks.on_payment_entry_submit",


### PR DESCRIPTION
## Summary
- expose new helper functions via __all__
- centralize company setup logic
- hook Company creation to use new setup_company

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dcb14c5e4832c821aa16f95816869