### PR TITLE
Add process flag to setup hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ bench --site your_site.local migrate
 
 2. **🔄 After Sync (Installation Tasks):** During `bench migrate` the app's
    `after_sync` hook runs installation routines such as creating default
-   accounts, suppliers, and salary structures. You can rerun this step
-   manually with:
+   accounts, suppliers, and salary structures. Use this for development or when
+   reinstalling the app. The routine sets a process flag to avoid running
+   twice if called repeatedly. You can rerun this step manually with:
 
 ```bash
 bench --site your_site.local execute payroll_indonesia.fixtures.setup.after_sync

--- a/payroll_indonesia/fixtures/setup.py
+++ b/payroll_indonesia/fixtures/setup.py
@@ -189,6 +189,9 @@ def after_install():
     """
     logger.info("Starting Payroll Indonesia after_install process")
 
+    if getattr(frappe.flags, "_payroll_initialized", False):
+        return
+
     if is_installation_complete():
         logger.info("Installation flag detected, skipping full install")
         return
@@ -203,6 +206,7 @@ def after_install():
 
     try:
         _run_full_install(skip_existing=True)
+        frappe.flags._payroll_initialized = True
         mark_installation_complete()
     except Exception as e:
         logger.error(f"Error during installation: {str(e)}", exc_info=True)
@@ -215,6 +219,9 @@ def after_install():
 def after_sync():
     """Run installation routines after Frappe sync."""
     logger.info("Starting after_sync process for Payroll Indonesia")
+
+    if getattr(frappe.flags, "_payroll_initialized", False):
+        return
 
     if is_after_sync_completed():
         logger.info("after_sync already completed, skipping")
@@ -237,6 +244,7 @@ def after_sync():
         # Run full installation but skip existing records so it's idempotent
         _run_full_install(skip_existing=True)
 
+        frappe.flags._payroll_initialized = True
         logger.info("after_sync process completed successfully")
 
         mark_installation_complete()


### PR DESCRIPTION
## Summary
- guard `after_install` and `after_sync` hooks with a runtime flag
- set the flag after a successful installation
- document using the hook for reinstallation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dd45dc3ec832c8c37b45c0fac5efa