### PR TITLE
Fix duplicate company setup

### DIFF
--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -55,7 +55,7 @@ doc_events = {
         "on_cancel": "payroll_indonesia.payroll_indonesia.doctype.bpjs_payment_summary.bpjs_payment_summary.on_cancel",
     },
     "Company": {
-        "after_insert": "payroll_indonesia.fixtures.setup.setup_company",
+        # on_update is triggered on both insert and update events
         "on_update": "payroll_indonesia.fixtures.setup.setup_company",
     },
     "Payment Entry": {


### PR DESCRIPTION
## Summary
- avoid running company setup twice when a `Company` is inserted

## Testing
- `pytest -q` *(fails: 24 skipped due to missing Frappe)*

------
https://chatgpt.com/codex/tasks/task_e_687dd68c8050832cb18603f1c672e1a1