### PR TITLE
Implement salary component GL sync

### DIFF
--- a/payroll_indonesia/payroll_indonesia/tests/test_salary_component_gl_sync.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_salary_component_gl_sync.py
@@ -1,0 +1,60 @@
+import unittest
+import pytest
+
+frappe = pytest.importorskip("frappe")
+
+from payroll_indonesia.config.gl_account_mapper import map_salary_component_to_gl
+from payroll_indonesia.config.gl_mapper_core import get_account_mapping_from_defaults
+from payroll_indonesia.config.config import get_config as get_default_config
+
+
+class TestSalaryComponentGLSync(unittest.TestCase):
+    def setUp(self):
+        self.company = frappe.defaults.get_user_default("Company")
+        self.mapping = get_account_mapping_from_defaults()
+
+    def tearDown(self):
+        frappe.db.rollback()
+
+    def ensure_component(self, name, comp_type="Earning"):
+        if not frappe.db.exists("Salary Component", name):
+            doc = frappe.get_doc({
+                "doctype": "Salary Component",
+                "salary_component": name,
+                "type": comp_type,
+            })
+            doc.insert(ignore_permissions=True)
+
+    def test_mapping_creates_account_row(self):
+        component = "Gaji Pokok"
+        self.ensure_component(component)
+        frappe.db.delete("Salary Component Account", {"parent": component, "company": self.company})
+
+        defaults = get_default_config()
+        mapped = map_salary_component_to_gl(self.company, defaults)
+        self.assertIn(component, mapped)
+
+        account_name = self.mapping.get(component)
+        self.assertIsNotNone(account_name)
+        abbr = frappe.get_cached_value("Company", self.company, "abbr")
+        full_name = f"{account_name} - {abbr}"
+
+        row = frappe.get_value(
+            "Salary Component Account",
+            {"parent": component, "company": self.company},
+            "default_account",
+        )
+        self.assertEqual(row, full_name)
+        self.assertTrue(frappe.db.exists("Account", full_name))
+
+        # Idempotency
+        before = frappe.get_all(
+            "Salary Component Account",
+            filters={"parent": component, "company": self.company},
+        )
+        map_salary_component_to_gl(self.company, defaults)
+        after = frappe.get_all(
+            "Salary Component Account",
+            filters={"parent": component, "company": self.company},
+        )
+        self.assertEqual(len(before), len(after))


### PR DESCRIPTION
## Summary
- add `map_salary_component_to_gl` helper for syncing salary component accounts
- test salary component GL mapping via defaults

## Testing
- `pytest -k salary_component_gl_sync -q`


------
https://chatgpt.com/codex/tasks/task_e_687ddf1b4d80832ca27a4275876ee033