### PR TITLE
Update docs for new GL mapping table

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,14 @@ from payroll_indonesia.fixtures import setup
 setup.after_install()
 ```
 
-5. Salary Slips now include a `calculate_indonesia_tax` checkbox (default enabled).
+5. **📥 Migrate GL Account Mappings:** Populate the new `gl_account_mappings` table
+   from the JSON fields:
+
+```bash
+bench --site your_site.local execute payroll_indonesia.setup.settings_migration.migrate_cli
+```
+
+6. Salary Slips now include a `calculate_indonesia_tax` checkbox (default enabled).
    When upgrading, slips generated from a Payroll Entry with this flag checked
    will still calculate Indonesian tax even if the custom field has not been
    created yet.

--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -30,7 +30,8 @@ Global payroll defaults like currency, working days and payroll frequency. Value
 Values used when creating the default salary structure and for related fields in **Payroll Indonesia Settings** (e.g. `basic_salary_percent`, `meal_allowance`).
 
 ## gl_accounts
-Chart of Accounts templates for payroll. Includes `root_account`, `expense_accounts`, `payable_accounts` and BPJS related accounts. Data is stored as JSON in the settings fields `expense_accounts_json`, `payable_accounts_json`, `parent_accounts_json` and `bpjs_account_mapping_json`.
+Chart of Accounts templates for payroll. Includes `root_account`, `expense_accounts`, `payable_accounts` and BPJS related accounts. Values are inserted into the **GL Account Mapping Entry** table on **Payroll Indonesia Settings** and also stored as JSON in the legacy fields `expense_accounts_json`, `payable_accounts_json`, `parent_accounts_json` and `bpjs_account_mapping_json`.
+Each mapping row contains `account_key`, `category`, `account_name`, `account_type`, `root_type` and an `is_group` flag.
 
 The `bpjs_account_mapping_json` object mirrors the **BPJS Account Mapping** DocType. It stores the GL account fields used when creating the default mapping for each company. Current field names include:
 
@@ -49,6 +50,16 @@ jkk_employer_credit_account
 jkm_employer_debit_account
 jkm_employer_credit_account
 ```
+
+Existing setups that still use the JSON fields can migrate the values to
+`gl_account_mappings` by running:
+
+```bash
+bench --site your_site.local execute payroll_indonesia.setup.settings_migration.migrate_cli
+```
+
+The command reads `defaults.json` and populates the table along with the legacy
+fields when they are empty.
 
 ### Expense accounts
 


### PR DESCRIPTION
## Summary
- document GL Account Mapping Entry in defaults docs
- explain how to run migration script for old JSON fields
- mention migration step in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dfdbdf010832ca899e2e7d58be13a