### PR TITLE
Remove unused ValidationError import

### DIFF
--- a/payroll_indonesia/config/gl_account_mapper.py
+++ b/payroll_indonesia/config/gl_account_mapper.py
@@ -6,7 +6,6 @@
 import frappe
 import logging
 import re
-from frappe.exceptions import ValidationError
 from typing import Optional
 
 from payroll_indonesia.config.config import (


### PR DESCRIPTION
## Summary
- clean up gl_account_mapper by removing unused `ValidationError` import

## Testing
- `pytest -q`
- flake8 *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dfee5ba3c832c9d830cfa4b169c75