### PR TITLE
Add GL JSON migration utility

### DIFF
--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -31,6 +31,10 @@ doctype_list_js = {
     "BPJS Account Mapping": "payroll_indonesia/doctype/bpjs_account_mapping/bpjs_account_mapping_list.js",
 }
 
+doctype_js = {
+    "Payroll Indonesia Settings": "payroll_indonesia/doctype/payroll_indonesia_settings/payroll_indonesia_settings.js",
+}
+
 # ❹ Document Events - primary hooks for document lifecycle
 doc_events = {
     "Employee": {

--- a/payroll_indonesia/payroll_indonesia/doctype/payroll_indonesia_settings/payroll_indonesia_settings.js
+++ b/payroll_indonesia/payroll_indonesia/doctype/payroll_indonesia_settings/payroll_indonesia_settings.js
@@ -1,0 +1,14 @@
+frappe.ui.form.on('Payroll Indonesia Settings', {
+    refresh: function(frm) {
+        const has_json = frm.doc.expense_accounts_json || frm.doc.payable_accounts_json;
+        if (!frm.doc.gl_account_mappings?.length && has_json) {
+            frm.add_custom_button(__('Migrate GL Account JSON'), async function() {
+                await frappe.call({
+                    method: 'payroll_indonesia.payroll_indonesia.doctype.payroll_indonesia_settings.payroll_indonesia_settings.migrate_json_to_child_table'
+                });
+                await frm.reload_doc();
+            }, __('Actions'));
+        }
+    }
+});
+

--- a/payroll_indonesia/payroll_indonesia/tests/test_json_migration.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_json_migration.py
@@ -1,0 +1,72 @@
+import importlib
+import json
+import sys
+import types
+
+
+def setup_frappe(settings):
+    frappe = types.ModuleType("frappe")
+    frappe.utils = types.ModuleType("frappe.utils")
+    frappe.utils.cint = int
+    frappe.utils.flt = float
+    frappe.utils.now = lambda: None
+    frappe.utils.get_site_path = lambda *a, **k: ""
+    frappe._ = lambda x: x
+    frappe.msgprint = lambda *a, **k: None
+    frappe.whitelist = lambda *a, **k: (lambda f: f)
+    frappe.get_single = lambda name: settings
+    sys.modules["frappe"] = frappe
+    sys.modules["frappe.utils"] = frappe.utils
+
+    model = types.ModuleType("frappe.model")
+    document = types.ModuleType("frappe.model.document")
+    document.Document = object
+    sys.modules["frappe.model"] = model
+    sys.modules["frappe.model.document"] = document
+
+    return frappe
+
+
+def test_migrate_json_to_child_table(monkeypatch):
+    settings = types.SimpleNamespace(
+        gl_account_mappings=[],
+        expense_accounts_json=json.dumps({"gaji": {"account_name": "Beban Gaji"}}),
+        payable_accounts_json=json.dumps({"hutang": {"account_name": "Hutang"}}),
+        flags=types.SimpleNamespace(),
+    )
+    settings.append = lambda table, row: settings.gl_account_mappings.append(row)
+    settings.save = lambda ignore_permissions=True: None
+
+    setup_frappe(settings)
+
+    mod = importlib.import_module(
+        "payroll_indonesia.payroll_indonesia.doctype.payroll_indonesia_settings.payroll_indonesia_settings"
+    )
+
+    count = mod.migrate_json_to_child_table()
+
+    assert count == 2
+    assert settings.gl_account_mappings[0]["account_key"] == "gaji"
+    assert settings.gl_account_mappings[1]["category"] == "payable_accounts"
+
+
+def test_migrate_json_skips_when_table_filled(monkeypatch):
+    settings = types.SimpleNamespace(
+        gl_account_mappings=[{"account_key": "existing"}],
+        expense_accounts_json=json.dumps({"gaji": {"account_name": "Beban Gaji"}}),
+        payable_accounts_json=json.dumps({"hutang": {"account_name": "Hutang"}}),
+        flags=types.SimpleNamespace(),
+    )
+    settings.append = lambda *a, **k: settings.gl_account_mappings.append({})
+    settings.save = lambda ignore_permissions=True: None
+
+    setup_frappe(settings)
+
+    mod = importlib.import_module(
+        "payroll_indonesia.payroll_indonesia.doctype.payroll_indonesia_settings.payroll_indonesia_settings"
+    )
+
+    count = mod.migrate_json_to_child_table()
+
+    assert count == 0
+    assert len(settings.gl_account_mappings) == 1


### PR DESCRIPTION
## Summary
- support migrating old GL JSON fields into the child table
- load custom JS on settings to trigger migration
- expose `migrate_json_to_child_table` via whitelist
- test migration logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dffad1178832cbd78c1207ae7d8b1