### PR TITLE
Remove legacy JSON account fields

### DIFF
--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -30,7 +30,7 @@ Global payroll defaults like currency, working days and payroll frequency. Value
 Values used when creating the default salary structure and for related fields in **Payroll Indonesia Settings** (e.g. `basic_salary_percent`, `meal_allowance`).
 
 ## gl_accounts
-Chart of Accounts templates for payroll. Includes `root_account`, `expense_accounts`, `payable_accounts` and BPJS related accounts. Values are inserted into the **GL Account Mapping Entry** table on **Payroll Indonesia Settings** and also stored as JSON in the legacy fields `expense_accounts_json`, `payable_accounts_json`, `parent_accounts_json` and `bpjs_account_mapping_json`.
+Chart of Accounts templates for payroll. Includes `root_account`, `expense_accounts`, `payable_accounts` and BPJS related accounts. Values are inserted into the **GL Account Mapping Entry** table on **Payroll Indonesia Settings**. The `bpjs_account_mapping_json` field stores BPJS‑specific mappings for backward compatibility.
 Each mapping row contains `account_key`, `category`, `account_name`, `account_type`, `root_type` and an `is_group` flag.
 
 The `bpjs_account_mapping_json` object mirrors the **BPJS Account Mapping** DocType. It stores the GL account fields used when creating the default mapping for each company. Current field names include:
@@ -51,15 +51,14 @@ jkm_employer_debit_account
 jkm_employer_credit_account
 ```
 
-Existing setups that still use the JSON fields can migrate the values to
-`gl_account_mappings` by running:
+If you are upgrading from an older version that stored accounts in JSON fields,
+you can migrate them into `gl_account_mappings` by running:
 
 ```bash
 bench --site your_site.local execute payroll_indonesia.setup.settings_migration.migrate_cli
 ```
 
-The command reads `defaults.json` and populates the table along with the legacy
-fields when they are empty.
+The command reads `defaults.json` and populates the table when it is empty.
 
 ### Expense accounts
 

--- a/payroll_indonesia/config/gl_mapper_core.py
+++ b/payroll_indonesia/config/gl_mapper_core.py
@@ -138,9 +138,6 @@ def _seed_gl_account_mappings(settings: "frappe.Document", defaults: Dict[str, A
 
         mappings = [
             ("bpjs_account_mapping_json", bpjs_gl_accounts),
-            ("expense_accounts_json", gl_accounts.get("expense_accounts", {})),
-            ("payable_accounts_json", gl_accounts.get("payable_accounts", {})),
-            ("parent_accounts_json", gl_accounts.get("root_account", {})),
         ]
 
         for field, value in mappings:

--- a/payroll_indonesia/payroll_indonesia/doctype/payroll_indonesia_settings/payroll_indonesia_settings.json
+++ b/payroll_indonesia/payroll_indonesia/doctype/payroll_indonesia_settings/payroll_indonesia_settings.json
@@ -309,24 +309,6 @@
       "options": "GL Account Mapping Entry"
     },
     {
-      "fieldname": "expense_accounts_json",
-      "fieldtype": "Code",
-      "label": "Expense Accounts (JSON)",
-      "options": "JSON"
-    },
-    {
-      "fieldname": "payable_accounts_json",
-      "fieldtype": "Code",
-      "label": "Payable Accounts (JSON)",
-      "options": "JSON"
-    },
-    {
-      "fieldname": "parent_accounts_json",
-      "fieldtype": "Code",
-      "label": "Parent Accounts (JSON)",
-      "options": "JSON"
-    },
-    {
       "fieldname": "fallback_parent_accounts_section",
       "fieldtype": "Section Break",
       "label": "Fallback Parent Accounts",

--- a/payroll_indonesia/payroll_indonesia/tests/test_defaults_export.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_defaults_export.py
@@ -56,9 +56,6 @@ class TestWriteDefaults(unittest.TestCase):
             ter_rate_table=[
                 DummyRow(status_pajak="TER A", income_from=0, income_to=5400000, rate=0)
             ],
-            expense_accounts_json=json.dumps({"gaji": {"account_name": "Gaji"}}),
-            payable_accounts_json=json.dumps({"pph": {"account_name": "Hutang"}}),
-            parent_accounts_json=json.dumps({"root": {"account_name": "Payroll"}}),
             parent_account_candidates_expense="Expenses",
             parent_account_candidates_liability="Liabilities",
             expense_account_prefix="Beban",
@@ -77,8 +74,6 @@ class TestWriteDefaults(unittest.TestCase):
         self.assertEqual(data["bpjs"]["kesehatan_employee_percent"], 1.0)
         self.assertIn("tax", data)
         self.assertEqual(data["tax"]["umr_default"], 5000000.0)
-        self.assertIn("gl_accounts", data)
-        self.assertIn("gaji", data["gl_accounts"]["expense_accounts"])
         self.assertEqual(data["settings"]["expense_account_prefix"], "Beban")
 
 

--- a/payroll_indonesia/payroll_indonesia/utils.py
+++ b/payroll_indonesia/payroll_indonesia/utils.py
@@ -604,19 +604,6 @@ def write_json_file_if_enabled(doc) -> bool:
     if tax_effect_mappings:
         export_data["component_tax_effects"] = tax_effect_mappings
 
-    # --- GL accounts ---
-    gl_accounts: Dict[str, Any] = {}
-    try:
-        if getattr(doc, "expense_accounts_json", None):
-            gl_accounts["expense_accounts"] = json.loads(doc.expense_accounts_json)
-        if getattr(doc, "payable_accounts_json", None):
-            gl_accounts["payable_accounts"] = json.loads(doc.payable_accounts_json)
-        if getattr(doc, "parent_accounts_json", None):
-            gl_accounts["parent_accounts"] = json.loads(doc.parent_accounts_json)
-    except Exception:
-        logger.warning("Invalid GL account JSON in settings")
-    if gl_accounts:
-        export_data["gl_accounts"] = gl_accounts
 
     # --- other settings section ---
     export_data["settings"] = {

--- a/payroll_indonesia/setup/settings_migration.py
+++ b/payroll_indonesia/setup/settings_migration.py
@@ -577,9 +577,6 @@ def _update_bpjs_settings(settings: "frappe.Document", defaults: Dict[str, Any])
         # the BPJS config
         json_fields = [
             ("bpjs_account_mapping_json", "gl_accounts", {}),
-            ("expense_accounts_json", "expense_accounts", {}),
-            ("payable_accounts_json", "payable_accounts", {}),
-            ("parent_accounts_json", "parent_accounts", {}),
         ]
 
         for field, config_key, default_value in json_fields:


### PR DESCRIPTION
## Summary
- drop `expense_accounts_json`, `payable_accounts_json` and `parent_accounts_json`
- stop exporting the removed fields
- simplify GL account mapping seeding
- update settings migration
- adjust tests and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e18313844832cbe979ff79297e639