### PR TITLE
Remove struktur_gaji_umr_default

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/payroll_indonesia_settings/payroll_indonesia_settings.json
+++ b/payroll_indonesia/payroll_indonesia/doctype/payroll_indonesia_settings/payroll_indonesia_settings.json
@@ -456,13 +456,6 @@
       "reqd": 1
     },
     {
-      "fieldname": "struktur_gaji_umr_default",
-      "fieldtype": "Currency",
-      "label": "Default UMR (Salary Structure)",
-      "default": 4900000.0,
-      "reqd": 1
-    },
-    {
       "fieldname": "tipe_karyawan_section",
       "fieldtype": "Section Break",
       "label": "Employee Types",

--- a/payroll_indonesia/setup/settings_migration.py
+++ b/payroll_indonesia/setup/settings_migration.py
@@ -504,7 +504,7 @@ def _update_general_settings(settings: "frappe.Document", defaults: Dict[str, An
                 ("basic_salary_percent", "basic_salary_percent", 75),
                 ("meal_allowance", "meal_allowance", 750000.0),
                 ("transport_allowance", "transport_allowance", 900000.0),
-                ("struktur_gaji_umr_default", "umr_default", 4900000.0),
+                ("umr_default", "umr_default", 4900000.0),
                 ("position_allowance_percent", "position_allowance_percent", 7.5),
                 ("hari_kerja_default", "hari_kerja_default", 22),
             ]


### PR DESCRIPTION
## Summary
- remove `struktur_gaji_umr_default` field from Payroll Indonesia Settings
- use `umr_default` for salary structure defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e1b00d17c832c84565ff496a26370