### PR TITLE
Remove unused attendance flag

### DIFF
--- a/payroll_indonesia/config/defaults.json
+++ b/payroll_indonesia/config/defaults.json
@@ -790,7 +790,6 @@
     },
     "defaults": {
         "currency": "IDR",
-        "attendance_based_on_timesheet": 0,
         "payroll_frequency": "Monthly",
         "salary_slip_based_on": "Leave Policy",
         "max_working_days_per_month": 22,

--- a/payroll_indonesia/payroll_indonesia/doctype/payroll_indonesia_settings/payroll_indonesia_settings.json
+++ b/payroll_indonesia/payroll_indonesia/doctype/payroll_indonesia_settings/payroll_indonesia_settings.json
@@ -354,12 +354,6 @@
       "reqd": 1
     },
     {
-      "fieldname": "attendance_based_on_timesheet",
-      "fieldtype": "Check",
-      "label": "Attendance Based on Timesheet",
-      "default": 0
-    },
-    {
       "fieldname": "column_break_defaults",
       "fieldtype": "Column Break"
     },


### PR DESCRIPTION
## Summary
- drop `attendance_based_on_timesheet` from defaults
- remove the related field from settings form

## Testing
- `pytest -k none -q`
- ❌ `flake8` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_687e1d1a9a84832c9ba12c97d4f70e98