### PR TITLE
Migrate BPJS mapping JSON

### DIFF
--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -60,6 +60,10 @@ bench --site your_site.local execute payroll_indonesia.setup.settings_migration.
 
 The command reads `defaults.json` and populates the table when it is empty.
 
+BPJS account mappings defined in the legacy `bpjs_account_mapping_json` field are
+now migrated automatically to the **BPJS Account Mapping** DocType when running
+the module's `after_migrate` routine.
+
 ### Expense accounts
 
 The `expense_accounts` object defines GL accounts for common salary components:

--- a/payroll_indonesia/payroll_indonesia/tests/test_after_migrate.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_after_migrate.py
@@ -1,9 +1,11 @@
 import unittest
 from unittest.mock import patch
+import json
 import pytest
 
 frappe = pytest.importorskip("frappe")
 from payroll_indonesia.setup import setup_module
+from payroll_indonesia.payroll_indonesia.utils import get_or_create_account
 
 
 class TestAfterMigrateBPJSMapping(unittest.TestCase):
@@ -34,6 +36,52 @@ class TestAfterMigrateBPJSMapping(unittest.TestCase):
         ):
             setup_module.after_migrate()
         self.assertTrue(frappe.db.exists("BPJS Account Mapping", {"company": self.company.name}))
+
+    def test_bpjs_json_migrated(self):
+        settings = frappe.get_single("Payroll Indonesia Settings")
+        settings.company = self.company.name
+        settings.bpjs_account_mapping_json = json.dumps(
+            {
+                "kesehatan_employee_account": "BPJS Kesehatan Payable",
+                "kesehatan_employer_debit_account": "BPJS Kesehatan Employer Expense",
+            }
+        )
+        settings.flags.ignore_permissions = True
+        settings.save()
+
+        get_or_create_account(
+            self.company.name,
+            "BPJS Kesehatan Payable",
+            "Payable",
+            root_type="Liability",
+        )
+        get_or_create_account(
+            self.company.name,
+            "BPJS Kesehatan Employer Expense",
+            "Expense Account",
+            root_type="Expense",
+        )
+
+        if frappe.db.exists("BPJS Account Mapping", {"company": self.company.name}):
+            frappe.db.delete("BPJS Account Mapping", {"company": self.company.name})
+
+        with patch.object(setup_module, "setup_accounts", return_value=True), patch.object(
+            setup_module, "_load_defaults", return_value=None
+        ), patch("payroll_indonesia.fixtures.setup.setup_default_salary_structure"), patch(
+            "payroll_indonesia.fixtures.setup.setup_salary_components"
+        ):
+            setup_module.after_migrate()
+
+        name = frappe.db.get_value("BPJS Account Mapping", {"company": self.company.name}, "name")
+        doc = frappe.get_doc("BPJS Account Mapping", name)
+        self.assertEqual(
+            doc.kesehatan_employee_account,
+            f"BPJS Kesehatan Payable - {self.company.abbr}",
+        )
+        self.assertEqual(
+            doc.kesehatan_employer_debit_account,
+            f"BPJS Kesehatan Employer Expense - {self.company.abbr}",
+        )
 
 
 if __name__ == "__main__":

--- a/payroll_indonesia/setup/bpjs.py
+++ b/payroll_indonesia/setup/bpjs.py
@@ -9,22 +9,24 @@ Provides functions to set up BPJS account mappings.
 
 import frappe
 from frappe.utils import cint
+import json
 from payroll_indonesia.frappe_helpers import logger
+
 
 def ensure_bpjs_account_mappings(doc=None, method=None, transaction_open=False) -> bool:
     """
     Ensure each company has a BPJS Account Mapping.
-    
+
     This can be called:
     - As a hook from Company DocType
     - Directly from other setup functions
     - Via command line
-    
+
     Args:
         doc: Optional Company document (when called from hooks)
         method: Unused hook parameter
         transaction_open: Whether a DB transaction is already open
-        
+
     Returns:
         bool: True if any mappings were created, False otherwise
     """
@@ -34,22 +36,22 @@ def ensure_bpjs_account_mappings(doc=None, method=None, transaction_open=False) 
         )
 
         company_name = getattr(doc, "name", None) if doc else None
-        
+
         if company_name:
             # Called from Company hook, only process this company
             companies = [company_name]
         else:
             # Process all companies
             companies = frappe.get_all("Company", pluck="name")
-        
+
         if not companies:
             logger.warning("No companies found for BPJS account mapping")
             return False
-            
+
         created = False
         for company in companies:
             logger.debug(f"Checking BPJS account mapping for company: {company}")
-            
+
             if not frappe.db.exists("BPJS Account Mapping", {"company": company}):
                 try:
                     create_default_mapping(company)
@@ -64,9 +66,9 @@ def ensure_bpjs_account_mappings(doc=None, method=None, transaction_open=False) 
             logger.info(f"Created BPJS account mappings for {len(companies)} companies")
         else:
             logger.info("No new BPJS account mappings needed")
-            
+
         return created
-        
+
     except Exception as e:
         logger.error(f"Error ensuring BPJS Account Mappings: {str(e)}")
         return False
@@ -75,71 +77,118 @@ def ensure_bpjs_account_mappings(doc=None, method=None, transaction_open=False) 
 def verify_bpjs_accounts(company=None) -> dict:
     """
     Verify that all required BPJS accounts exist for the given company.
-    
+
     Args:
         company: Company name to verify accounts for (optional, all companies if None)
-        
+
     Returns:
         dict: Results of verification with missing accounts
     """
     try:
         from payroll_indonesia.payroll_indonesia.doctype.bpjs_account_mapping.bpjs_account_mapping import (
-            get_mapping_for_company
+            get_mapping_for_company,
         )
-        
+
         results = {}
-        
+
         # Get companies to check
         if company:
             companies = [company]
         else:
             companies = frappe.get_all("Company", pluck="name")
-            
+
         for company_name in companies:
             # Check BPJS mapping existence
             mapping_exists = frappe.db.exists("BPJS Account Mapping", {"company": company_name})
-            
+
             # Get mapping details if it exists
             if mapping_exists:
                 mapping = get_mapping_for_company(company_name)
-                
+
                 # Check required accounts
                 missing_accounts = []
-                
+
                 account_fields = [
-                    "kesehatan_account", 
+                    "kesehatan_account",
                     "kesehatan_expense_account",
-                    "jht_account", 
+                    "jht_account",
                     "jht_expense_account",
-                    "jp_account", 
+                    "jp_account",
                     "jp_expense_account",
-                    "jkk_account", 
+                    "jkk_account",
                     "jkk_expense_account",
-                    "jkm_account", 
-                    "jkm_expense_account"
+                    "jkm_account",
+                    "jkm_expense_account",
                 ]
-                
+
                 for field in account_fields:
                     account = mapping.get(field)
                     if not account or not frappe.db.exists("Account", account):
                         missing_accounts.append(field)
-                
+
                 results[company_name] = {
                     "mapping_exists": True,
                     "complete": len(missing_accounts) == 0,
-                    "missing_accounts": missing_accounts
+                    "missing_accounts": missing_accounts,
                 }
             else:
                 results[company_name] = {
                     "mapping_exists": False,
                     "complete": False,
-                    "missing_accounts": ["No BPJS account mapping found"]
+                    "missing_accounts": ["No BPJS account mapping found"],
                 }
-                
+
         return results
     except Exception as e:
         logger.error(f"Error verifying BPJS accounts: {str(e)}")
         return {"error": str(e)}
+
+
+def migrate_bpjs_account_mapping_json() -> bool:
+    """Migrate legacy JSON mapping from settings to the BPJS Account Mapping DocType."""
+    try:
+        settings = frappe.get_single("Payroll Indonesia Settings")
+        company = getattr(settings, "company", None)
+        raw = getattr(settings, "bpjs_account_mapping_json", None)
+        if not company or not raw:
+            return False
+
+        try:
+            mapping_data = json.loads(raw) if isinstance(raw, str) else raw
+        except Exception:
+            logger.warning("Invalid bpjs_account_mapping_json")
+            return False
+
+        from payroll_indonesia.payroll_indonesia.doctype.bpjs_account_mapping.bpjs_account_mapping import (
+            create_default_mapping,
+            ACCOUNT_FIELDS,
+        )
+
+        if not frappe.db.exists("BPJS Account Mapping", {"company": company}):
+            create_default_mapping(company)
+
+        name = frappe.db.get_value("BPJS Account Mapping", {"company": company}, "name")
+        if not name:
+            return False
+
+        doc = frappe.get_doc("BPJS Account Mapping", name)
+        abbr = frappe.get_cached_value("Company", company, "abbr")
+        changed = False
+        for field in ACCOUNT_FIELDS:
+            value = mapping_data.get(field)
+            if not value or doc.get(field):
+                continue
+            candidate = f"{value} - {abbr}" if not value.endswith(f" - {abbr}") else value
+            if frappe.db.exists("Account", candidate):
+                doc.set(field, candidate)
+                changed = True
+        if changed:
+            doc.flags.ignore_permissions = True
+            doc.save(ignore_permissions=True)
+        return changed
+    except Exception as e:
+        logger.error(f"Error migrating BPJS account mapping JSON: {e}")
+        return False
 
 
 def setup_bpjs_mapping_cli():
@@ -149,25 +198,25 @@ def setup_bpjs_mapping_cli():
     """
     try:
         print("Setting up BPJS account mappings for all companies...")
-        
+
         result = ensure_bpjs_account_mappings()
-        
+
         if result:
             print("BPJS account mappings created successfully")
         else:
             print("No new BPJS account mappings needed")
-            
+
         # Verify the mappings
         verification = verify_bpjs_accounts()
-        
+
         print("\nVerification Results:")
         for company, status in verification.items():
             print(f"\nCompany: {company}")
             print(f"  Mapping exists: {status['mapping_exists']}")
             print(f"  Complete: {status['complete']}")
-            
-            if not status['complete']:
+
+            if not status["complete"]:
                 print(f"  Missing accounts: {', '.join(status['missing_accounts'])}")
-                
+
     except Exception as e:
         print(f"Error setting up BPJS account mappings: {e}")

--- a/payroll_indonesia/setup/setup_module.py
+++ b/payroll_indonesia/setup/setup_module.py
@@ -19,6 +19,10 @@ from payroll_indonesia.utilities.install_flag import (
     is_installation_complete,
     mark_installation_complete,
 )
+from payroll_indonesia.setup.bpjs import (
+    ensure_bpjs_account_mappings,
+    migrate_bpjs_account_mapping_json,
+)
 
 logger = get_logger("setup")
 
@@ -121,6 +125,7 @@ def setup_accounts(config=None, specific_company=None, *, skip_existing=False):
         # Setup BPJS account mappings
         try:
             from payroll_indonesia.setup.bpjs import ensure_bpjs_account_mappings
+
             bpjs_created = ensure_bpjs_account_mappings()
             tax_results["bpjs_mappings"] = bpjs_created
             if bpjs_created:
@@ -297,6 +302,8 @@ def after_migrate():
 
         # Core setup that must always run
         ensure_settings_doctype_exists()
+        ensure_bpjs_account_mappings()
+        migrate_bpjs_account_mapping_json()
 
         if is_installation_complete():
             logger.info("Installation flag detected, skipping full install")
@@ -304,6 +311,7 @@ def after_migrate():
 
         # Delegate to fixtures.setup for the main installation
         from payroll_indonesia.fixtures.setup import perform_essential_setup
+
         perform_essential_setup()
         mark_installation_complete()
         logger.info("Post-migration setup completed successfully")


### PR DESCRIPTION
## Summary
- migrate bpjs_account_mapping_json into BPJS Account Mapping
- invoke migration during `after_migrate`
- verify migration in tests
- document automatic BPJS mapping migration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e20da49cc832cb5d562da48da80bd