### PR TITLE
Fix duplicate decorator

### DIFF
--- a/payroll_indonesia/payroll_indonesia/utils.py
+++ b/payroll_indonesia/payroll_indonesia/utils.py
@@ -126,7 +126,6 @@ def safe_execute(default_value: Any = None, log_exception: bool = True) -> Calla
 
 
 @safe_execute(default_value=None)
-@safe_execute(default_value=None)
 def get_or_create_account(
     company: str,
     account_name: str,


### PR DESCRIPTION
## Summary
- remove duplicated `@safe_execute` on `get_or_create_account`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e39bff3c4832cbf8b15a545f525a1