### PR TITLE
Add config utilities for settings

### DIFF
--- a/payroll_indonesia/payroll_indonesia/config/__init__.py
+++ b/payroll_indonesia/payroll_indonesia/config/__init__.py
@@ -1,0 +1,19 @@
+from .config import (
+    get_bpjs_cap,
+    get_bpjs_rate,
+    get_ptkp_amount,
+    get_settings,
+    get_ter_code,
+    get_ter_rate,
+    get_value,
+)
+
+__all__ = [
+    "get_settings",
+    "get_value",
+    "get_bpjs_rate",
+    "get_bpjs_cap",
+    "get_ptkp_amount",
+    "get_ter_code",
+    "get_ter_rate",
+]

--- a/payroll_indonesia/payroll_indonesia/config/config.py
+++ b/payroll_indonesia/payroll_indonesia/config/config.py
@@ -1,0 +1,53 @@
+import frappe
+from frappe.utils import flt
+
+SETTINGS_DOCTYPE = "Payroll Indonesia Settings"
+SETTINGS_NAME = "Payroll Indonesia Settings"
+
+
+def get_settings():
+    """Return cached Payroll Indonesia Settings document."""
+    return frappe.get_cached_doc(SETTINGS_DOCTYPE, SETTINGS_NAME)
+
+
+def get_value(fieldname: str, default=None):
+    """Helper to fetch a field value from Payroll Indonesia Settings."""
+    return get_settings().get(fieldname, default)
+
+
+def get_bpjs_rate(fieldname: str) -> float:
+    """Return BPJS rate (%) for the given fieldname."""
+    return flt(get_value(fieldname))
+
+
+def get_bpjs_cap(fieldname: str) -> float:
+    """Return BPJS cap amount for the given fieldname."""
+    return flt(get_value(fieldname))
+
+
+def get_ptkp_amount(tax_status: str) -> float:
+    """Return PTKP amount for the given tax status."""
+    settings = get_settings()
+    for row in settings.get("ptkp_table", []):
+        if row.tax_status == tax_status:
+            return flt(row.ptkp_amount)
+    return 0.0
+
+
+def get_ter_code(tax_status: str) -> str | None:
+    """Return TER code mapping for the given tax status."""
+    settings = get_settings()
+    for row in settings.get("ter_mapping_table", []):
+        if row.tax_status == tax_status:
+            return row.ter_code
+    return None
+
+
+def get_ter_rate(ter_code: str, monthly_income: float) -> float:
+    """Return TER rate (%) for a given TER code and monthly income."""
+    settings = get_settings()
+    brackets = [b for b in settings.get("ter_bracket_table", []) if b.ter_code == ter_code]
+    for row in brackets:
+        if monthly_income >= row.min and (row.max == 0 or monthly_income <= row.max):
+            return flt(row.rate)
+    return 0.0


### PR DESCRIPTION
## Summary
- expose helper functions for `Payroll Indonesia Settings`
- make them available via new `config` module

## Testing
- `black payroll_indonesia/payroll_indonesia/config/config.py payroll_indonesia/payroll_indonesia/config/__init__.py`
- `isort payroll_indonesia/payroll_indonesia/config/config.py payroll_indonesia/payroll_indonesia/config/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68831e956910832cb9c0140d509981d9