### PR TITLE
Fix Document type hint causing install failure

### DIFF
--- a/payroll_indonesia/payroll_indonesia/setup/settings_migration.py
+++ b/payroll_indonesia/payroll_indonesia/setup/settings_migration.py
@@ -3,6 +3,7 @@ import os
 from typing import Any, Optional
 
 import frappe
+from frappe.model.document import Document
 
 def load_json(filename: str) -> Any:
     """
@@ -97,7 +98,7 @@ def import_ter_brackets() -> None:
     settings.save()
     frappe.logger().info("Imported default TER brackets")
 
-def get_or_create_settings() -> Optional[frappe.Document]:
+def get_or_create_settings() -> Optional[Document]:
     """Get or create Payroll Indonesia Settings document"""
     if not frappe.db.exists("Payroll Indonesia Settings", "Payroll Indonesia Settings"):
         settings = frappe.new_doc("Payroll Indonesia Settings")


### PR DESCRIPTION
## Summary
- import `Document` from `frappe.model.document`
- use `Optional[Document]` for settings migration helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838090b154832cb267ce96445abdfd