### PR TITLE
Fix default account parent search

### DIFF
--- a/payroll_indonesia/payroll_indonesia/setup/setup_module.py
+++ b/payroll_indonesia/payroll_indonesia/setup/setup_module.py
@@ -29,9 +29,20 @@ def create_default_accounts(company_name: str, company_abbr: str) -> None:
         gl_accounts = json.load(f)
 
     parent_account_options = {
-        "expense": ["Direct Expenses", "Pengeluaran Langsung", "Expenses", "Biaya"],
-        "liability": ["Payables", "Utang Usaha", "Current Liabilities", "Kewajiban Lancar"],
-        "tax": ["Duties and Taxes", "Utang Pajak"]
+        "expense": [
+            "Direct Expenses",
+            "Pengeluaran Langsung",
+            "Expenses",
+            "Biaya",
+        ],
+        "liability": [
+            "Payables",
+            "Utang Usaha",
+            "Current Liabilities",
+            "Kewajiban Lancar",
+            "Liabilities",
+        ],
+        "tax": ["Duties and Taxes", "Utang Pajak"],
     }
 
     for account in gl_accounts:
@@ -56,7 +67,6 @@ def create_default_accounts(company_name: str, company_abbr: str) -> None:
                     "company": company_name,
                     "root_type": "Expense",
                     "is_group": 1,
-                    "account_type": "Expense Account"
                 },
                 fields=["name"]
             )
@@ -71,7 +81,6 @@ def create_default_accounts(company_name: str, company_abbr: str) -> None:
                     "company": company_name,
                     "root_type": "Liability",
                     "is_group": 1,
-                    "account_type": "Payable"
                 },
                 fields=["name"]
             )
@@ -81,11 +90,12 @@ def create_default_accounts(company_name: str, company_abbr: str) -> None:
                 parent_account = get_parent_account(parent_account_options["liability"], company_abbr)
 
         if not parent_account:
-            frappe.log_error(
-                f"Cannot create account {account_name_with_abbr}: No suitable parent account found",
-                "Payroll Indonesia Setup"
+            message = (
+                f"Cannot create account {account_name_with_abbr}: "
+                "No suitable parent account found"
             )
-            continue
+            frappe.log_error(message, "Payroll Indonesia Setup")
+            raise frappe.ValidationError(message)
 
         try:
             new_account = frappe.get_doc({

--- a/payroll_indonesia/tests/test_setup_module.py
+++ b/payroll_indonesia/tests/test_setup_module.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import importlib
+from types import SimpleNamespace
+
+
+def make_fake_frappe():
+    created = []
+    logs = []
+
+    class DB:
+        def exists(self, doctype, name):
+            return name in {
+                "Expenses - TEST",
+                "Liabilities - TEST",
+                "Duties and Taxes - TEST",
+            }
+
+        def commit(self):
+            pass
+
+    def get_all(doctype, filters=None, fields=None):
+        assert "account_type" not in filters
+        if filters.get("root_type") == "Expense":
+            return [SimpleNamespace(name="Expenses - TEST")]
+        if filters.get("root_type") == "Liability":
+            return [SimpleNamespace(name="Liabilities - TEST")]
+        return []
+
+    def get_doc(doc):
+        class Doc(dict):
+            def insert(self, ignore_permissions=False):
+                created.append(self)
+        return Doc(doc)
+
+    def get_app_path(app, *parts):
+        base = os.path.join(os.path.dirname(os.path.dirname(__file__)), app)
+        return os.path.join(base, *parts)
+
+    def logger():
+        class L:
+            def info(self, msg):
+                logs.append(msg)
+        return L()
+
+    fake_frappe = SimpleNamespace(
+        db=SimpleNamespace(exists=DB().exists, commit=DB().commit),
+        get_all=get_all,
+        get_doc=get_doc,
+        get_app_path=get_app_path,
+        msgprint=lambda m: None,
+        log_error=lambda m, t=None: logs.append(m),
+        logger=logger,
+        ValidationError=Exception,
+    )
+
+    return fake_frappe, created, logs
+
+
+def test_create_default_accounts_no_account_type(monkeypatch):
+    fake_frappe, created, logs = make_fake_frappe()
+    sys.modules["frappe"] = fake_frappe
+    sys.modules[
+        "payroll_indonesia.payroll_indonesia.setup.gl_account_mapper"
+    ] = SimpleNamespace(assign_gl_accounts_to_salary_components=lambda *a, **k: None)
+    sys.modules[
+        "payroll_indonesia.payroll_indonesia.setup.settings_migration"
+    ] = SimpleNamespace(setup_default_settings=lambda: None)
+    setup_module = importlib.import_module(
+        "payroll_indonesia.payroll_indonesia.setup.setup_module"
+    )
+    monkeypatch.setattr(setup_module, "frappe", fake_frappe)
+
+    setup_module.create_default_accounts("Test Company", "TEST")
+
+    assert created, "Accounts were not created"


### PR DESCRIPTION
## Summary
- make expense/liability parent search ignore account_type
- log and raise if no parent found
- include "Liabilities" in fallback parent options
- test account creation without account_type filter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883848945e8832cac020b914e26d270