### PR TITLE
Gracefully handle missing account parents

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Referensi dan contoh hitung PPh 21, BPJS, serta perlakuan natura (PMK 168 & PMK 
    bench migrate
    ```
 4. Semua komponen, mapping, dan pengaturan akan otomatis terimport dan siap digunakan.
+5. Modul akan mencari nama grup akun umum seperti "Expenses" atau "Liabilities" sebagai induk akun payroll. Jika tidak ditemukan, akan digunakan grup akun pertama dengan `root_type` yang sama.
 
 ---
 

--- a/payroll_indonesia/tests/test_setup_module.py
+++ b/payroll_indonesia/tests/test_setup_module.py
@@ -4,12 +4,14 @@ import importlib
 from types import SimpleNamespace
 
 
-def make_fake_frappe():
+def make_fake_frappe(parents_exist=True):
     created = []
     logs = []
 
     class DB:
         def exists(self, doctype, name):
+            if not parents_exist:
+                return False
             return name in {
                 "Expenses - TEST",
                 "Liabilities - TEST",
@@ -19,18 +21,24 @@ def make_fake_frappe():
         def commit(self):
             pass
 
-    def get_all(doctype, filters=None, fields=None):
+    def get_all(doctype, filters=None, fields=None, pluck=None):
         assert "account_type" not in filters
+        if not parents_exist:
+            return []
+        result = []
         if filters.get("root_type") == "Expense":
-            return [SimpleNamespace(name="Expenses - TEST")]
-        if filters.get("root_type") == "Liability":
-            return [SimpleNamespace(name="Liabilities - TEST")]
-        return []
+            result = ["Expenses - TEST"] if pluck else [SimpleNamespace(name="Expenses - TEST")]
+        elif filters.get("root_type") == "Liability":
+            result = (
+                ["Liabilities - TEST"] if pluck else [SimpleNamespace(name="Liabilities - TEST")]
+            )
+        return result
 
     def get_doc(doc):
         class Doc(dict):
             def insert(self, ignore_permissions=False):
                 created.append(self)
+
         return Doc(doc)
 
     def get_app_path(app, *parts):
@@ -41,6 +49,10 @@ def make_fake_frappe():
         class L:
             def info(self, msg):
                 logs.append(msg)
+
+            def warning(self, msg):
+                logs.append(f"WARNING: {msg}")
+
         return L()
 
     fake_frappe = SimpleNamespace(
@@ -60,12 +72,12 @@ def make_fake_frappe():
 def test_create_default_accounts_no_account_type(monkeypatch):
     fake_frappe, created, logs = make_fake_frappe()
     sys.modules["frappe"] = fake_frappe
-    sys.modules[
-        "payroll_indonesia.payroll_indonesia.setup.gl_account_mapper"
-    ] = SimpleNamespace(assign_gl_accounts_to_salary_components=lambda *a, **k: None)
-    sys.modules[
-        "payroll_indonesia.payroll_indonesia.setup.settings_migration"
-    ] = SimpleNamespace(setup_default_settings=lambda: None)
+    sys.modules["payroll_indonesia.payroll_indonesia.setup.gl_account_mapper"] = SimpleNamespace(
+        assign_gl_accounts_to_salary_components=lambda *a, **k: None
+    )
+    sys.modules["payroll_indonesia.payroll_indonesia.setup.settings_migration"] = SimpleNamespace(
+        setup_default_settings=lambda: None
+    )
     setup_module = importlib.import_module(
         "payroll_indonesia.payroll_indonesia.setup.setup_module"
     )
@@ -74,3 +86,23 @@ def test_create_default_accounts_no_account_type(monkeypatch):
     setup_module.create_default_accounts("Test Company", "TEST")
 
     assert created, "Accounts were not created"
+
+
+def test_create_default_accounts_skip_when_no_parent(monkeypatch):
+    fake_frappe, created, logs = make_fake_frappe(parents_exist=False)
+    sys.modules["frappe"] = fake_frappe
+    sys.modules["payroll_indonesia.payroll_indonesia.setup.gl_account_mapper"] = SimpleNamespace(
+        assign_gl_accounts_to_salary_components=lambda *a, **k: None
+    )
+    sys.modules["payroll_indonesia.payroll_indonesia.setup.settings_migration"] = SimpleNamespace(
+        setup_default_settings=lambda: None
+    )
+    setup_module = importlib.import_module(
+        "payroll_indonesia.payroll_indonesia.setup.setup_module"
+    )
+    monkeypatch.setattr(setup_module, "frappe", fake_frappe)
+
+    setup_module.create_default_accounts("Test Company", "TEST")
+
+    assert not created, "Accounts should be skipped when no parent is found"
+    assert any("Skipping account" in log for log in logs)


### PR DESCRIPTION
## Summary
- fallback to the first group account when known parent names aren't found
- warn and skip account creation if no parent exists
- document the account group lookup behaviour in README
- test fallback logic and skipping behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883939901d8832ca4614b01a7bdf50d