### PR TITLE
Improve error logging during GL account setup

### DIFF
--- a/payroll_indonesia/payroll_indonesia/setup/setup_module.py
+++ b/payroll_indonesia/payroll_indonesia/setup/setup_module.py
@@ -80,7 +80,9 @@ def create_accounts_from_json() -> None:
                 doc.insert(ignore_if_duplicate=True, ignore_permissions=True)
                 frappe.logger().info(f"Created account {doc.name} for {company}")
             except Exception:
-                frappe.logger().info(f"Skipped account {acc.get('account_name')} for {company}")
+                frappe.logger().error(
+                    f"Skipped account {acc.get('account_name')} for {company}\n{traceback.format_exc()}"
+                )
         frappe.db.commit()
 
 


### PR DESCRIPTION
## Summary
- include stack trace when account creation fails during setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884c8e29414832c925a497977e03393