### PR TITLE
Fix parent account creation logic

### DIFF
--- a/payroll_indonesia/payroll_indonesia/setup/setup_module.py
+++ b/payroll_indonesia/payroll_indonesia/setup/setup_module.py
@@ -13,7 +13,7 @@ __all__ = ["after_sync"]
 
 def ensure_parent(name: str, company: str, root_type: str, report_type: str) -> bool:
     """Create parent account if missing."""
-    if frappe.db.exists("Account", {"account_name": name, "company": company}):
+    if frappe.db.exists("Account", name):
         return True
 
     try:
@@ -69,12 +69,14 @@ def create_accounts_from_json() -> None:
         for acc in accounts:
             parent = acc.get("parent_account")
             if parent:
-                parent_name = parent.rsplit(" - ", 1)[0]
                 if not ensure_parent(
-                    parent_name, company, acc.get("root_type"), acc.get("report_type")
+                    parent,
+                    company,
+                    acc.get("root_type"),
+                    acc.get("report_type"),
                 ):
                     frappe.logger().info(
-                        f"Skipped account {acc.get('account_name')} for {company} because parent {parent_name} is missing"
+                        f"Skipped account {acc.get('account_name')} for {company} because parent {parent} is missing"
                     )
                     continue
             try:
@@ -95,9 +97,7 @@ def after_sync() -> None:
         create_accounts_from_json()
         frappe.db.commit()
     except Exception:
-        frappe.logger().error(
-            f"Error creating GL accounts\n{traceback.format_exc()}"
-        )
+        frappe.logger().error(f"Error creating GL accounts\n{traceback.format_exc()}")
         frappe.db.rollback()
         return
 

--- a/payroll_indonesia/test_setup_module.py
+++ b/payroll_indonesia/test_setup_module.py
@@ -1,0 +1,28 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+frappe_import_mock = MagicMock()
+sys.modules["frappe"] = frappe_import_mock
+sys.modules["frappe.model"] = MagicMock()
+sys.modules["frappe.model.document"] = MagicMock()
+
+from payroll_indonesia.payroll_indonesia.setup import setup_module as setup_mod
+
+
+def test_ensure_parent_idempotent():
+    frappe_mock = MagicMock()
+
+    # First call should create the parent, second should detect existing
+    frappe_mock.db.exists.side_effect = [False, True]
+
+    doc_mock = MagicMock()
+    frappe_mock.get_doc.return_value = doc_mock
+
+    with patch.object(setup_mod, "frappe", frappe_mock):
+        assert setup_mod.ensure_parent("Expenses - AB", "Test Co", "Expense", "Profit and Loss")
+        assert setup_mod.ensure_parent("Expenses - AB", "Test Co", "Expense", "Profit and Loss")
+
+    # insert should be called only once when parent doesn't exist
+    assert doc_mock.insert.call_count == 1


### PR DESCRIPTION
## Summary
- ensure parent account existence checked by full name
- use full parent value when validating GL accounts
- add regression test for parent creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d7a030ec832cb7b7e4d71454b9d3