### PR TITLE
Fix hook invocation

### DIFF
--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -72,11 +72,15 @@ app_license = "MIT"
 
 # Integration Setup
 # ------------------
-# To set up dependencies/integrations with other apps
+# To set up dependencies/integrations with other apps.
+#
+# `after_sync` is executed immediately after DocType sync while
+# `after_migrate` runs later once all patches have been applied.
+# Running both hooks would call the setup twice, so we only use
+# `after_migrate`.
 after_migrate = [
     "payroll_indonesia.payroll_indonesia.setup.setup_module.after_sync"
 ]
-after_sync = after_migrate
 
 # Desk Notifications
 # ------------------


### PR DESCRIPTION
## Summary
- update hooks to use only `after_migrate`
- add comment explaining why `after_sync` isn't necessary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884eb26cdd8832cbfc8e9d87b3be8e3