### PR TITLE
Load income tax slab from doc

### DIFF
--- a/payroll_indonesia/test_settings_migration.py
+++ b/payroll_indonesia/test_settings_migration.py
@@ -7,7 +7,7 @@ sys.modules.setdefault("frappe", frappe_mock)
 sys.modules.setdefault("frappe.model", MagicMock())
 sys.modules.setdefault("frappe.model.document", MagicMock())
 
-from payroll_indonesia.payroll_indonesia.setup import settings_migration as mig
+from payroll_indonesia.setup import settings_migration as mig
 
 
 def test_get_or_create_settings_creates_without_commit():

--- a/payroll_indonesia/test_setup_module.py
+++ b/payroll_indonesia/test_setup_module.py
@@ -8,7 +8,7 @@ sys.modules["frappe"] = frappe_import_mock
 sys.modules["frappe.model"] = MagicMock()
 sys.modules["frappe.model.document"] = MagicMock()
 
-from payroll_indonesia.payroll_indonesia.setup import setup_module as setup_mod
+from payroll_indonesia.setup import setup_module as setup_mod
 
 
 def test_ensure_parent_idempotent():

--- a/payroll_indonesia/test_tax_slabs.py
+++ b/payroll_indonesia/test_tax_slabs.py
@@ -1,0 +1,33 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+# Mock frappe before importing the module
+frappe_mock = MagicMock()
+frappe_utils_mock = MagicMock(flt=lambda x: float(x))
+sys.modules.setdefault("frappe", frappe_mock)
+sys.modules.setdefault("frappe.utils", frappe_utils_mock)
+
+from payroll_indonesia.config import pph21_ter_december as dec
+
+
+def test_get_tax_slabs_returns_defaults_when_doc_missing():
+    frappe_mock = MagicMock()
+    frappe_mock.get_cached_doc.side_effect = Exception("Missing")
+    frappe_mock.logger.return_value = MagicMock()
+
+    with patch.object(dec, "frappe", frappe_mock), patch.object(dec.config, "get_value", return_value="x"):
+        assert dec.get_tax_slabs() == dec.DEFAULT_TAX_SLABS
+
+
+def test_get_tax_slabs_parse_document():
+    frappe_mock = MagicMock()
+    slab_rows = [
+        MagicMock(to_amount=1000, percent_deduction=10),
+        MagicMock(to_amount=0, percent_deduction=20),
+    ]
+    slab_doc = MagicMock()
+    slab_doc.get.return_value = slab_rows
+    frappe_mock.get_cached_doc.return_value = slab_doc
+
+    with patch.object(dec, "frappe", frappe_mock), patch.object(dec.config, "get_value", return_value="x"):
+        assert dec.get_tax_slabs() == [(1000.0, 10.0), (float("inf"), 20.0)]


### PR DESCRIPTION
## Summary
- fetch income tax slabs from Income Tax Slab document
- fix imports for tests
- test reading of tax slab document

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68857f33e224832c8c3b8b53fd78ca79