### PR TITLE
Implement Salary Slip override for Indonesian tax

### DIFF
--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -104,9 +104,10 @@ after_migrate = [
 # ---------------
 # Override standard doctype classes
 
-# override_doctype_class = {
-#	"ToDo": "custom_app.overrides.CustomToDo"
-# }
+override_doctype_class = {
+    "Payroll Entry": "payroll_indonesia.override.payroll_entry.CustomPayrollEntry",
+    "Salary Slip": "payroll_indonesia.override.salary_slip.CustomSalarySlip",
+}
 
 # Document Events
 # ---------------

--- a/payroll_indonesia/override/__init__.py
+++ b/payroll_indonesia/override/__init__.py
@@ -1,0 +1,4 @@
+from .payroll_entry import CustomPayrollEntry
+from .salary_slip import CustomSalarySlip
+
+__all__ = ["CustomPayrollEntry", "CustomSalarySlip"]

--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -1,0 +1,34 @@
+try:
+    from erpnext.payroll.doctype.salary_slip.salary_slip import SalarySlip
+except Exception:  # pragma: no cover - erpnext may not be installed during tests
+    SalarySlip = object  # type: ignore
+
+import frappe
+
+from payroll_indonesia.config import pph21_ter, pph21_ter_december
+
+
+class CustomSalarySlip(SalarySlip):
+    """Salary Slip with Indonesian income tax calculations."""
+
+    def calculate_income_tax(self):
+        """Calculate income tax using Indonesian rules."""
+        if getattr(self, "run_payroll_indonesia_december", False):
+            frappe.logger().info("Salary Slip: calculating PPh21 December mode.")
+            result = pph21_ter_december.calculate_pph21_TER_december(
+                self.employee, self
+            )
+            self.pph21_info = result
+            self.tax = result.get("pph21_month", 0)
+            self.tax_type = "DECEMBER"
+            return self.tax
+
+        if getattr(self, "run_payroll_indonesia", False):
+            frappe.logger().info("Salary Slip: calculating PPh21 TER mode.")
+            result = pph21_ter.calculate_pph21_TER(self.employee, self)
+            self.pph21_info = result
+            self.tax = result.get("pph21", 0)
+            self.tax_type = "TER"
+            return self.tax
+
+        return super().calculate_income_tax()


### PR DESCRIPTION
## Summary
- add a salary slip override to calculate Indonesian PPh21
- expose overrides via package init
- hook Payroll Entry and Salary Slip overrides in hooks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688631410198832ca458e3c03e113eeb