### PR TITLE
Fix after_sync commit logic

### DIFF
--- a/payroll_indonesia/setup/setup_module.py
+++ b/payroll_indonesia/setup/setup_module.py
@@ -185,6 +185,8 @@ def after_sync() -> None:
 
     try:
         setup_default_settings()
+        frappe.db.commit()
+        frappe.logger().info("✅ Payroll GL Setup completed")
     except Exception:
         frappe.logger().error(
             f"Error setting up default Payroll Indonesia settings\n{traceback.format_exc()}"


### PR DESCRIPTION
## Summary
- commit database after settings setup
- log that payroll setup is complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68863452d4e8832c9be118b8f9688f28