### PR TITLE
Add employee link to Annual Payroll History

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.json
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.json
@@ -14,6 +14,14 @@
       "reqd": 1
     },
     {
+      "fieldname": "employee",
+      "fieldtype": "Link",
+      "label": "Employee",
+      "options": "Employee",
+      "reqd": 1,
+      "in_list_view": 1
+    },
+    {
       "fieldname": "bruto_total",
       "fieldtype": "Currency",
       "label": "Total Bruto",
@@ -57,5 +65,5 @@
       "options": "Annual Payroll History Child"
     }
   ],
-  "modified": "2024-01-01 00:00:00"
+  "modified": "2024-01-02 00:00:00"
 }


### PR DESCRIPTION
## Summary
- insert an Employee link field on Annual Payroll History doctype
- bump the modified timestamp

## Testing
- `pytest -q`
- `bench migrate` *(fails: command not found)*
- `bench clear-cache` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68879b3799e4832c82caf389887bb54c