### PR TITLE
Remove unused imports and fix newline endings

### DIFF
--- a/payroll_indonesia/config/pph21_ter.py
+++ b/payroll_indonesia/config/pph21_ter.py
@@ -1,4 +1,3 @@
-import frappe
 from frappe.utils import flt
 from payroll_indonesia.config import config
 

--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.py
@@ -1,4 +1,3 @@
-import frappe
 from frappe.model.document import Document
 
 class AnnualPayrollHistory(Document):

--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history_child/annual_payroll_history_child.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history_child/annual_payroll_history_child.py
@@ -1,4 +1,3 @@
-import frappe
 from frappe.model.document import Document
 
 class AnnualPayrollHistoryChild(Document):

--- a/payroll_indonesia/setup/gl_account_mapper.py
+++ b/payroll_indonesia/setup/gl_account_mapper.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Dict, Any, List
+from typing import Dict
 
 import frappe
 


### PR DESCRIPTION
## Summary
- trim unused `frappe` imports from payroll utilities
- drop unused `Any` and `List` from `gl_account_mapper`
- ensure files end with a newline

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6887a3fd5544832cb4886ebca38bd788