### PR TITLE
Fix configuration helpers import

### DIFF
--- a/payroll_indonesia/config/pph21_ter.py
+++ b/payroll_indonesia/config/pph21_ter.py
@@ -1,33 +1,5 @@
 from frappe.utils import flt
-from payroll_indonesia.config import config
-
-def get_ter_code(tax_status):
-    """Ambil kode TER dari tax_status via settings/mapping table."""
-    settings = config.get_settings()
-    for row in settings.get("ter_mapping_table", []):
-        if row.tax_status == tax_status:
-            return row.ter_code
-    return None
-
-def get_ter_rate(ter_code, monthly_income):
-    """Cari rate TER (%) untuk kode dan penghasilan tertentu dari tabel setting."""
-    settings = config.get_settings()
-    brackets = [b for b in settings.get("ter_bracket_table", []) if b.ter_code == ter_code]
-    for row in brackets:
-        min_income = flt(row.min_income or 0)
-        max_income = flt(row.max_income or 0)
-        rate = flt(row.rate_percent or 0)
-        if monthly_income >= min_income and (max_income == 0 or monthly_income <= max_income):
-            return rate
-    return 0.0
-
-def get_ptkp_amount(tax_status):
-    """Ambil PTKP dari table di settings."""
-    settings = config.get_settings()
-    for row in settings.get("ptkp_table", []):
-        if row.tax_status == tax_status:
-            return flt(row.ptkp_amount)
-    return 0.0
+from payroll_indonesia.config import get_ptkp_amount, get_ter_code, get_ter_rate
 
 def sum_bruto_earnings(salary_slip):
     """

--- a/payroll_indonesia/config/pph21_ter_december.py
+++ b/payroll_indonesia/config/pph21_ter_december.py
@@ -1,6 +1,11 @@
 import frappe
 from frappe.utils import flt
-from payroll_indonesia.config import config
+from payroll_indonesia.config import (
+    config,
+    get_ptkp_amount,
+    get_ter_code,
+    get_ter_rate,
+)
 
 # Default progressive income tax slabs (PMK 168/2023, berlaku 2024)
 DEFAULT_TAX_SLABS = [
@@ -37,13 +42,6 @@ def get_tax_slabs():
     slabs.sort(key=lambda x: x[0])
     return slabs
 
-def get_ptkp_amount(tax_status):
-    """Ambil PTKP dari table di settings."""
-    settings = config.get_settings()
-    for row in settings.get("ptkp_table", []):
-        if row.tax_status == tax_status:
-            return flt(row.ptkp_amount)
-    return 0.0
 
 def sum_bruto_earnings(salary_slip):
     """
@@ -317,7 +315,6 @@ def calculate_pph21_TER_december_from_annual_payroll(annual_payroll_history, emp
 
     # --- Perhitungan PPh21 Desember ---
     # PTKP tahunan
-    from .pph21_ter_december import get_ptkp_amount, calculate_pkp_annual, calculate_pph21_progressive, get_tax_slabs
 
     ptkp_annual = get_ptkp_amount(tax_status)
     pkp_annual = calculate_pkp_annual(netto_total, ptkp_annual)


### PR DESCRIPTION
## Summary
- reuse get_ptkp_amount, get_ter_code and get_ter_rate from `payroll_indonesia.config`
- remove redundant helper implementations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888b1e3720c832c8cf0208fadb98613