### PR TITLE
Add min/max to safe formula evaluation

### DIFF
--- a/payroll_indonesia/__init__.py
+++ b/payroll_indonesia/__init__.py
@@ -1,1 +1,16 @@
 __version__ = "1.0.0"
+
+# Ensure Python built-ins ``min`` and ``max`` are available during formula
+# evaluation in Salary Structure and Salary Slip.  ERPNext's safe execution
+# environment does not expose these by default which causes evaluation errors
+# for formulas like ``min(base, cap)``.  If frappe is not installed the import
+# will fail (for example when running static analysis), therefore wrap the
+# update in ``try/except``.
+try:  # pragma: no cover - frappe might not be available during tests
+    from frappe.utils.safe_exec import get_safe_globals
+
+    safe_globals = get_safe_globals()
+    safe_globals.setdefault("min", min)
+    safe_globals.setdefault("max", max)
+except Exception:
+    pass

--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -8,6 +8,19 @@ import frappe
 from payroll_indonesia.config import pph21_ter, pph21_ter_december
 from payroll_indonesia.utils import sync_annual_payroll_history
 
+# ERPNext's safe execution environment used when evaluating Salary Component
+# formulas does not expose ``min`` and ``max`` by default.  Some Payroll
+# Indonesia components rely on these functions (e.g. BPJS calculations).  Make
+# sure they're available globally when this module is imported.
+try:  # pragma: no cover - frappe may not be installed during tests
+    from frappe.utils.safe_exec import get_safe_globals
+
+    safe_globals = get_safe_globals()
+    safe_globals.setdefault("min", min)
+    safe_globals.setdefault("max", max)
+except Exception:
+    pass
+
 class CustomSalarySlip(SalarySlip):
     """
     Salary Slip with Indonesian income tax calculations (TER bulanan dan Progressive/Desember).


### PR DESCRIPTION
## Summary
- expose Python built‑ins `min` and `max` for formula evaluations
- ensure min and max are available when custom salary slip module loads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888bd72dbe0832c85fac352755d4ff0