### PR TITLE
Fix custom salary slip path in docs

### DIFF
--- a/docs/custom_salary_slip.md
+++ b/docs/custom_salary_slip.md
@@ -16,7 +16,7 @@ Tambahkan mapping berikut pada `override_doctype_class` di `hooks.py` agar ERPNe
 
 ```python
 override_doctype_class = {
-    "Salary Slip": "payroll_indonesia.override.custom_salary_slip.CustomSalarySlip",
+    "Salary Slip": "payroll_indonesia.override.salary_slip.CustomSalarySlip",
     "Payroll Entry": "payroll_indonesia.override.payroll_entry.CustomPayrollEntry",
 }
 ```


### PR DESCRIPTION
## Summary
- correct the override path for CustomSalarySlip in docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888c8676978832c8c31f3e1b325150b