### PR TITLE
Expose config helpers to safe exec

### DIFF
--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -5,10 +5,15 @@ app_description = "Payroll Indonesia - Modul Perhitungan BPJS & PPh 21 untuk ERP
 app_email = "hello@imogi.tech"
 app_license = "MIT"
 
-# Python built-ins exposed in Frappe's safe execution environment
+# Helper functions exposed in Frappe's safe execution environment
 safe_exec_globals = {
-    "min": "builtins.min",
-    "max": "builtins.max",
+    "min_value": "payroll_indonesia.utils.min_value",
+    "max_value": "payroll_indonesia.utils.max_value",
+    "get_bpjs_cap": "payroll_indonesia.utils.get_bpjs_cap",
+    "get_bpjs_rate": "payroll_indonesia.utils.get_bpjs_rate",
+    "get_ptkp_amount": "payroll_indonesia.utils.get_ptkp_amount",
+    "get_ter_code": "payroll_indonesia.utils.get_ter_code",
+    "get_ter_rate": "payroll_indonesia.utils.get_ter_rate",
 }
 
 # Includes in <head>

--- a/payroll_indonesia/utils/config.py
+++ b/payroll_indonesia/utils/config.py
@@ -1,12 +1,21 @@
-from .config import (
-    min_value,
-    max_value,
+from payroll_indonesia.config import (
     get_bpjs_cap,
     get_bpjs_rate,
     get_ptkp_amount,
     get_ter_code,
     get_ter_rate,
 )
+
+
+def min_value(*values):
+    """Return the minimum of the provided values."""
+    return min(*values)
+
+
+def max_value(*values):
+    """Return the maximum of the provided values."""
+    return max(*values)
+
 
 __all__ = [
     "min_value",


### PR DESCRIPTION
## Summary
- add min/max helper utilities
- expose config helpers for safe execution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888cd27ebf8832c8b2d347370eea519