### PR TITLE
Expose BPJS helpers to salary slip formulas

### DIFF
--- a/docs/payroll_indonesia_settings.md
+++ b/docs/payroll_indonesia_settings.md
@@ -85,3 +85,6 @@ Komponen seperti BPJS akan menggunakan helper function untuk membaca rate/cap:
 
 ```python
 min(base, get_bpjs_cap("bpjs_health_employer_cap")) * get_bpjs_rate("bpjs_health_employer_rate")
+```
+
+Fungsi `get_bpjs_cap()` dan `get_bpjs_rate()` tersedia otomatis di formula Salary Component setelah modul ini terpasang.

--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -111,6 +111,14 @@ override_doctype_class = {
     "Salary Slip": "payroll_indonesia.override.salary_slip.CustomSalarySlip",
 }
 
+# Safe Eval Globals
+# -----------------
+# Tambahan fungsi yang dapat dipanggil pada formula Salary Component.
+salary_slip_globals = {
+    "get_bpjs_cap": "payroll_indonesia.config.get_bpjs_cap",
+    "get_bpjs_rate": "payroll_indonesia.config.get_bpjs_rate",
+}
+
 # Document Events
 # ---------------
 # Hook on document methods and events


### PR DESCRIPTION
## Summary
- register helper functions so salary slip formulas can call `get_bpjs_rate` and `get_bpjs_cap`
- document that those helpers are available for formulas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888df3aad48832cb3ab790ed059a502