### PR TITLE
Handle missing PTKP and TER bracket data with ValidationError

### DIFF
--- a/payroll_indonesia/config/config.py
+++ b/payroll_indonesia/config/config.py
@@ -40,11 +40,9 @@ def get_ptkp_amount_from_tax_status(tax_status: str) -> float:
     Return PTKP amount for the given tax_status from PTKP Table.
     """
     if not tax_status:
-        frappe.logger().warning("PTKP amount lookup: tax_status is empty.")
-        return 0.0
+        raise ValidationError("PTKP amount lookup: tax_status is empty.")
     if not frappe.db.exists("PTKP Table", {"tax_status": tax_status}):
-        frappe.logger().warning(f"PTKP Table: tax_status '{tax_status}' not found.")
-        return 0.0
+        raise ValidationError(f"PTKP Table: tax_status '{tax_status}' not found.")
     row = frappe.get_value(
         "PTKP Table",
         {"tax_status": tax_status},
@@ -102,8 +100,9 @@ def get_ter_rate(ter_code: str, monthly_income: float) -> float:
         order_by="min_income asc",
     )
     if not brackets:
-        frappe.logger().warning(f"TER Bracket Table: No brackets found for ter_code '{ter_code}'.")
-        return 0.0
+        raise ValidationError(
+            f"TER Bracket Table: No brackets found for ter_code '{ter_code}'."
+        )
     for row in brackets:
         min_income = flt(row.get("min_income") or 0)
         max_income = flt(row.get("max_income") or 0)
@@ -111,10 +110,9 @@ def get_ter_rate(ter_code: str, monthly_income: float) -> float:
         # If max_income == 0, treat as infinity
         if monthly_income >= min_income and (max_income == 0 or monthly_income <= max_income):
             return rate
-    frappe.logger().warning(
+    raise ValidationError(
         f"TER Bracket Table: No bracket match for ter_code '{ter_code}' and monthly_income {monthly_income}."
     )
-    return 0.0
 
 def is_auto_queue_salary_slip() -> bool:
     """

--- a/payroll_indonesia/config/pph21_ter.py
+++ b/payroll_indonesia/config/pph21_ter.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import ValidationError
 from frappe.utils import flt
 from payroll_indonesia.config import (
     get_ptkp_amount,
@@ -101,7 +102,11 @@ def calculate_pph21_TER(employee_doc, salary_slip):
         }
 
     # PTKP bulanan
-    ptkp = get_ptkp_amount(employee_doc) / 12
+    try:
+        ptkp = get_ptkp_amount(employee_doc) / 12
+    except ValidationError as e:
+        frappe.logger().warning(str(e))
+        ptkp = 0.0
 
     # Earnings: penghasilan bruto (termasuk natura taxable)
     bruto = sum_bruto_earnings(salary_slip)
@@ -120,7 +125,11 @@ def calculate_pph21_TER(employee_doc, salary_slip):
 
     # TER code & rate
     ter_code = get_ter_code(employee_doc)
-    rate = get_ter_rate(ter_code, pkp)
+    try:
+        rate = get_ter_rate(ter_code, pkp)
+    except ValidationError as e:
+        frappe.logger().warning(str(e))
+        rate = 0.0
     frappe.logger().info(f"TER code: {ter_code}, rate: {rate}")
 
     # PPh21

--- a/payroll_indonesia/config/pph21_ter_december.py
+++ b/payroll_indonesia/config/pph21_ter_december.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import ValidationError
 from frappe.utils import flt
 from payroll_indonesia.config import (
     config,
@@ -170,7 +171,11 @@ def calculate_pph21_TER_december(employee_doc, salary_slips, pph21_paid_jan_nov=
 
     netto_total = bruto_total - pengurang_netto_total - biaya_jabatan_total
 
-    ptkp_annual = get_ptkp_amount(employee_doc)
+    try:
+        ptkp_annual = get_ptkp_amount(employee_doc)
+    except ValidationError as e:
+        frappe.logger().warning(str(e))
+        ptkp_annual = 0.0
     pkp_annual = calculate_pkp_annual(netto_total, ptkp_annual)
     pph21_annual = calculate_pph21_progressive(pkp_annual)
     koreksi_pph21 = pph21_annual - pph21_paid_jan_nov
@@ -270,7 +275,11 @@ def calculate_pph21_TER_december_from_annual_payroll(annual_payroll_history, emp
         if bulan and int(bulan) < 12:
             pph21_paid_jan_nov += float(pph21 or 0)
 
-    ptkp_annual = get_ptkp_amount(employee_doc)
+    try:
+        ptkp_annual = get_ptkp_amount(employee_doc)
+    except ValidationError as e:
+        frappe.logger().warning(str(e))
+        ptkp_annual = 0.0
     pkp_annual = calculate_pkp_annual(netto_total, ptkp_annual)
     pph21_annual = calculate_pph21_progressive(pkp_annual)
     koreksi_pph21 = pph21_annual - pph21_paid_jan_nov


### PR DESCRIPTION
## Summary
- raise `ValidationError` in `get_ptkp_amount_from_tax_status` and `get_ter_rate`
- catch those exceptions in TER calculation helpers so payroll continues gracefully

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889f3247e20832c895eaefa2cc8b30f