### PR TITLE
Store PPh21 calculation info

### DIFF
--- a/payroll_indonesia/fixtures/custom_field.json
+++ b/payroll_indonesia/fixtures/custom_field.json
@@ -235,5 +235,25 @@
     "in_list_view": 1,
     "description": "Tunjangan uang transport bulanan",
     "modified": "2024-01-01 00:00:00"
+  },
+  {
+    "doctype": "Custom Field",
+    "name": "Salary Slip-pph21_info",
+    "dt": "Salary Slip",
+    "fieldname": "pph21_info",
+    "label": "PPh21 Info",
+    "fieldtype": "Text",
+    "insert_after": "tax",
+    "options": "",
+    "reqd": 0,
+    "default": "",
+    "depends_on": "",
+    "hidden": 0,
+    "no_copy": 0,
+    "print_hide": 0,
+    "in_filter": 0,
+    "in_list_view": 0,
+    "description": "Detail perhitungan PPh21 (JSON)",
+    "modified": "2024-01-01 00:00:00"
   }
 ]

--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -12,6 +12,7 @@ except Exception:
 
 import frappe
 from frappe.utils.safe_exec import safe_eval
+import json
 
 from payroll_indonesia.config import pph21_ter, pph21_ter_december
 from payroll_indonesia.utils import sync_annual_payroll_history
@@ -69,7 +70,7 @@ class CustomSalarySlip(SalarySlip):
                 salary_slips,
                 pph21_paid_jan_nov=pph21_paid_jan_nov,
             )
-            self.pph21_info = result
+            self.pph21_info = json.dumps(result)
             self.tax = result.get("koreksi_pph21", 0)
             self.tax_type = "DECEMBER"
             self.sync_to_annual_payroll_history(result, mode="december")
@@ -80,7 +81,7 @@ class CustomSalarySlip(SalarySlip):
             frappe.logger().info("Salary Slip: calculating PPh21 TER mode.")
             employee_doc = self.get_employee_doc()
             result = pph21_ter.calculate_pph21_TER(employee_doc, self)
-            self.pph21_info = result
+            self.pph21_info = json.dumps(result)
             self.tax = result.get("pph21", 0)
             self.tax_type = "TER"
             self.sync_to_annual_payroll_history(result, mode="monthly")


### PR DESCRIPTION
## Summary
- add a `pph21_info` custom field for Salary Slip fixture
- write calculation output to this field in `CustomSalarySlip`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889f535de5c832c97159728688400e5