### PR TITLE
Add December tax calculation for payroll

### DIFF
--- a/payroll_indonesia/override/payroll_entry.py
+++ b/payroll_indonesia/override/payroll_entry.py
@@ -69,7 +69,7 @@ class CustomPayrollEntry(PayrollEntry):
             slips = []
         for slip in slips:
             slip_obj = self._get_salary_slip_obj(slip)
-            slip_obj.calculate_income_tax()
+            slip_obj.calculate_income_tax_december()
             if isinstance(slip, dict):
                 slip["pph21_info"] = getattr(slip_obj, "pph21_info", {})
                 slip["tax"] = getattr(slip_obj, "tax", 0)


### PR DESCRIPTION
## Summary
- add method for December PPh21 calculation and annual sync
- use December calculation in payroll entry and validation

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement frappe>=15.0.0)
- `pytest` (fails: 3 failed, 9 passed)


------
https://chatgpt.com/codex/tasks/task_e_688b26345d1c832ca5cb9023bd152717