### PR TITLE
Sync monthly tax history

### DIFF
--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -79,6 +79,7 @@ class CustomSalarySlip(SalarySlip):
         self.tax_type = "TER"
 
         self.update_pph21_row(tax_amount)
+        self.sync_to_annual_payroll_history(result, mode="monthly")
         return tax_amount
 
     def calculate_income_tax_december(self):


### PR DESCRIPTION
## Summary
- Sync calculated monthly income tax to annual payroll history in `calculate_income_tax`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c38a643c4832cbca57314701cf4ed