### PR TITLE
Fix fiscal year detection in payroll sync

### DIFF
--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -173,9 +173,9 @@ class CustomSalarySlip(SalarySlip):
         """Sync slip result to Annual Payroll History."""
         try:
             employee_doc = self.get_employee_doc()
-            fiscal_year = (
-                getattr(self, "fiscal_year", None) or str(getattr(self, "start_date", ""))[:4]
-            )
+            fiscal_year = getattr(self, "fiscal_year", None) or str(
+                getattr(self, "start_date", None) or ""
+            )[:4]
             if not fiscal_year:
                 return
 


### PR DESCRIPTION
## Summary
- handle missing start_date when determining fiscal_year for annual payroll sync

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement frappe>=15.0.0)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c398e9bec832c9399b1eaa4f49310