### PR TITLE
Ensure numeric rate for annual payroll history

### DIFF
--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -232,6 +232,9 @@ class CustomSalarySlip(SalarySlip):
                     month_number = month_map.get(str(month_name).strip().lower())
             month_number = month_number or 0
 
+            # Ensure numeric rate for Annual Payroll History child
+            raw_rate = result.get("rate", 0)
+            numeric_rate = raw_rate if isinstance(raw_rate, (int, float)) else 0
             monthly_result = {
                 "bulan": month_number,
                 "bruto": result.get("bruto", result.get("bruto_total", 0)),
@@ -241,7 +244,7 @@ class CustomSalarySlip(SalarySlip):
                 "biaya_jabatan": result.get("biaya_jabatan", result.get("biaya_jabatan_total", 0)),
                 "netto": result.get("netto", result.get("netto_total", 0)),
                 "pkp": result.get("pkp", result.get("pkp_annual", 0)),
-                "rate": result.get("rate", ""),
+                "rate": flt(numeric_rate),
                 "pph21": result.get("pph21", result.get("pph21_month", 0)),
                 "salary_slip": self.name,
             }
@@ -262,6 +265,9 @@ class CustomSalarySlip(SalarySlip):
                     "pph21_annual": result.get("pph21_annual", 0),
                     "koreksi_pph21": result.get("koreksi_pph21", 0),
                 }
+                # Preserve slab string separately for reporting if available
+                if isinstance(raw_rate, str) and raw_rate:
+                    summary["rate_slab"] = raw_rate
                 sync_annual_payroll_history.sync_annual_payroll_history(
                     employee=employee_doc,
                     fiscal_year=fiscal_year,

--- a/payroll_indonesia/tests/test_sync_month_numeric.py
+++ b/payroll_indonesia/tests/test_sync_month_numeric.py
@@ -93,3 +93,88 @@ def test_sync_to_annual_payroll_history_sets_numeric_month(monkeypatch):
     ]:
         sys.modules.pop(mod, None)
 
+
+def test_sync_to_annual_payroll_history_december_rate_numeric(monkeypatch):
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+    frappe = types.ModuleType("frappe")
+    utils_mod = types.ModuleType("frappe.utils")
+    safe_exec_mod = types.ModuleType("frappe.utils.safe_exec")
+
+    class DummyLogger:
+        def info(self, msg):
+            pass
+
+        def warning(self, msg):
+            pass
+
+        def error(self, msg):
+            pass
+
+    def logger():
+        return DummyLogger()
+
+    def flt(val, precision=None):
+        return float(val)
+
+    def getdate(val):
+        return datetime.datetime.strptime(val, "%Y-%m-%d")
+
+    def safe_eval(expr, context=None):
+        return eval(expr, context or {})
+
+    frappe.logger = logger
+    frappe.get_doc = lambda *args, **kwargs: {}
+    frappe.throw = lambda *args, **kwargs: None
+    frappe.utils = utils_mod
+    utils_mod.flt = flt
+    utils_mod.getdate = getdate
+    safe_exec_mod.safe_eval = safe_eval
+
+    sys.modules["frappe"] = frappe
+    sys.modules["frappe.utils"] = utils_mod
+    sys.modules["frappe.utils.safe_exec"] = safe_exec_mod
+
+    salary_slip_mod = importlib.import_module("payroll_indonesia.override.salary_slip")
+    CustomSalarySlip = salary_slip_mod.CustomSalarySlip
+
+    captured = {}
+
+    def fake_sync(**kwargs):
+        captured["monthly"] = kwargs.get("monthly_results", [])
+        captured["summary"] = kwargs.get("summary")
+
+    monkeypatch.setattr(
+        salary_slip_mod.sync_annual_payroll_history,
+        "sync_annual_payroll_history",
+        fake_sync,
+    )
+
+    result = {
+        "bruto": 0,
+        "pengurang_netto": 0,
+        "biaya_jabatan": 0,
+        "netto": 0,
+        "pkp": 0,
+        "rate": "5%/15%/25%",
+        "pph21": 0,
+    }
+
+    ss = CustomSalarySlip()
+    ss.employee = {"name": "EMP-001"}
+    ss.name = "SS-DEC"
+    ss.fiscal_year = "2024"
+    ss.start_date = "2024-12-10"
+    ss.sync_to_annual_payroll_history(result, mode="december")
+
+    assert captured["monthly"][0]["rate"] == 0
+    assert captured["summary"]["rate_slab"] == "5%/15%/25%"
+
+    for mod in [
+        "frappe",
+        "frappe.utils",
+        "frappe.utils.safe_exec",
+        "payroll_indonesia.override.salary_slip",
+        "payroll_indonesia.utils.sync_annual_payroll_history",
+    ]:
+        sys.modules.pop(mod, None)


### PR DESCRIPTION
## Summary
- ensure Annual Payroll History child `rate` field is numeric when syncing December slips
- keep TER slab string separately in annual summary
- test December sync for numeric rate and stored slab string

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c51c4d028832cbc3004f1667e7fd1