### PR TITLE
feat: expose meal and transport allowances to salary formulas

### DIFF
--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -46,6 +46,18 @@ class CustomSalarySlip(SalarySlip):
         context = data.copy()
         context.update(_patch_salary_slip_globals())
 
+        # Inject custom allowance fields so formulas can reference them
+        ssa = getattr(self, "salary_structure_assignment", None)
+        for field in ("meal_allowance", "transport_allowance"):
+            value = getattr(self, field, None)
+            if value is None and ssa:
+                if isinstance(ssa, dict):
+                    value = ssa.get(field)
+                else:
+                    value = getattr(ssa, field, None)
+            if value is not None:
+                context[field] = value
+
         try:
             if getattr(struct_row, "condition", None):
                 if not safe_eval(struct_row.condition, context):

--- a/payroll_indonesia/tests/test_z_payroll_entry_december.py
+++ b/payroll_indonesia/tests/test_z_payroll_entry_december.py
@@ -31,6 +31,7 @@ def test_create_slip_in_december_mode(monkeypatch):
 
     frappe.utils = utils_mod
     frappe.logger = logger
+    frappe.db = types.SimpleNamespace(exists=lambda doctype, name: True)
 
     # Store slip data so get_doc can build a CustomSalarySlip later
     frappe._slip_data = {

--- a/tests/test_salary_slip_formula.py
+++ b/tests/test_salary_slip_formula.py
@@ -1,0 +1,42 @@
+import sys
+import os
+import types
+import importlib
+
+
+def test_eval_formula_with_allowances(monkeypatch):
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+    frappe = types.ModuleType("frappe")
+    utils_mod = types.ModuleType("frappe.utils")
+    safe_exec_mod = types.ModuleType("frappe.utils.safe_exec")
+
+    frappe.get_hooks = lambda *args, **kwargs: {}
+    frappe.get_attr = lambda path: None
+    frappe.log_error = lambda *args, **kwargs: None
+    utils_mod.safe_exec = safe_exec_mod
+    utils_mod.flt = lambda val, precision=None: float(val)
+    safe_exec_mod.safe_eval = lambda expr, context=None: eval(expr, context or {})
+    frappe.utils = utils_mod
+
+    sys.modules["frappe"] = frappe
+    sys.modules["frappe.utils"] = utils_mod
+    sys.modules["frappe.utils.safe_exec"] = safe_exec_mod
+
+    salary_slip_module = importlib.import_module("payroll_indonesia.override.salary_slip")
+    CustomSalarySlip = salary_slip_module.CustomSalarySlip
+
+    struct_row = types.SimpleNamespace(formula="meal_allowance + transport_allowance", condition=None)
+
+    slip = CustomSalarySlip()
+    slip.meal_allowance = 50
+    slip.transport_allowance = 75
+    assert slip.eval_condition_and_formula(struct_row, {}) == 125
+
+    delattr(slip, "meal_allowance")
+    delattr(slip, "transport_allowance")
+    slip.salary_structure_assignment = types.SimpleNamespace(meal_allowance=100, transport_allowance=120)
+    assert slip.eval_condition_and_formula(struct_row, {}) == 220
+
+    for mod in ["frappe", "frappe.utils", "frappe.utils.safe_exec", "payroll_indonesia.override.salary_slip"]:
+        sys.modules.pop(mod, None)


### PR DESCRIPTION
## Summary
- expose `meal_allowance` and `transport_allowance` to salary component formulas, pulling from the Salary Structure Assignment when needed
- add regression test demonstrating formulas using these allowances
- patch December payroll test to include `frappe.db` stub

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cd56619e0832c9ab095ad2740c254