### PR TITLE
fix: allow saving unsaved payroll history

### DIFF
--- a/payroll_indonesia/utils/sync_annual_payroll_history.py
+++ b/payroll_indonesia/utils/sync_annual_payroll_history.py
@@ -193,7 +193,9 @@ def sync_annual_payroll_history(employee, fiscal_year, monthly_results=None, sum
                 f"for employee '{employee_name}', fiscal year {fiscal_year} "
                 f"at {frappe.utils.now()}"
             )
-            history.save(ignore_permissions=True)
+            # Salary Slip is unsaved during validate, so ignore link checks
+            # or move this sync to a post-insert hook
+            history.save(ignore_permissions=True, ignore_links=True)
             return history.name
         except Exception as e:
             frappe.log_error(


### PR DESCRIPTION
## Summary
- ignore link validation when saving Annual Payroll History if Salary Slip not stored yet
- document that unsaved slips require ignore_links or moving sync post-insert

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*
- `pip install frappe erpnext` *(fails: Could not find a version that satisfies the requirement frappe)*

------
https://chatgpt.com/codex/tasks/task_e_688d7ca73cd0832c8c02d11c6829bfd0