### PR TITLE
refactor: align annual payroll totals with docfields

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.js
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.js
@@ -32,20 +32,16 @@ frappe.ui.form.on('Annual Payroll History Child', {
 });
 
 function calculate_totals(frm) {
-    let bruto = 0, pengurang_netto = 0, biaya_jabatan = 0, netto = 0, pkp = 0, pph21 = 0;
+    let bruto = 0, netto = 0, pkp = 0, pph21 = 0;
     $.each(frm.doc.monthly_details || [], function(i, row) {
         bruto += flt(row.bruto);
-        pengurang_netto += flt(row.pengurang_netto);
-        biaya_jabatan += flt(row.biaya_jabatan);
         netto += flt(row.netto);
         pkp += flt(row.pkp);
         pph21 += flt(row.pph21);
     });
-    frm.set_value('total_bruto', bruto);
-    frm.set_value('total_pengurang_netto', pengurang_netto);
-    frm.set_value('total_biaya_jabatan', biaya_jabatan);
-    frm.set_value('total_netto', netto);
-    frm.set_value('total_pkp', pkp);
-    frm.set_value('total_pph21', pph21);
-    frm.refresh_fields(['total_bruto', 'total_pengurang_netto', 'total_biaya_jabatan', 'total_netto', 'total_pkp', 'total_pph21']);
+    frm.set_value('bruto_total', bruto);
+    frm.set_value('netto_total', netto);
+    frm.set_value('pkp_annual', pkp);
+    frm.set_value('pph21_annual', pph21);
+    frm.refresh_fields(['bruto_total', 'netto_total', 'pkp_annual', 'pph21_annual']);
 }

--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.py
@@ -3,18 +3,14 @@ from frappe.model.document import Document
 class AnnualPayrollHistory(Document):
     def validate(self):
         # Inisialisasi total
-        self.total_bruto = 0
-        self.total_pengurang_netto = 0
-        self.total_biaya_jabatan = 0
-        self.total_netto = 0
-        self.total_pkp = 0
-        self.total_pph21 = 0
+        self.bruto_total = 0
+        self.netto_total = 0
+        self.pkp_annual = 0
+        self.pph21_annual = 0
 
         # Penjumlahan dari child table
         for row in self.monthly_details:
-            self.total_bruto += row.bruto or 0
-            self.total_pengurang_netto += row.pengurang_netto or 0
-            self.total_biaya_jabatan += row.biaya_jabatan or 0
-            self.total_netto += row.netto or 0
-            self.total_pkp += row.pkp or 0
-            self.total_pph21 += row.pph21 or 0
+            self.bruto_total += row.bruto or 0
+            self.netto_total += row.netto or 0
+            self.pkp_annual += row.pkp or 0
+            self.pph21_annual += row.pph21 or 0


### PR DESCRIPTION
## Summary
- use new DocType fields when calculating annual payroll totals
- drop unused pengurang_netto and biaya_jabatan totals

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*


------
https://chatgpt.com/codex/tasks/task_e_688d8fe5fb24832c8efec5115b87cf01