### PR TITLE
Add title formatting for annual payroll history child

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history_child/annual_payroll_history_child.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history_child/annual_payroll_history_child.py
@@ -1,4 +1,7 @@
+import frappe
 from frappe.model.document import Document
 
+
 class AnnualPayrollHistoryChild(Document):
-    pass
+    def get_title(self):
+        return f"Bulan {self.bulan} - Netto {frappe.utils.fmt_money(self.netto)}"


### PR DESCRIPTION
## Summary
- add frappe import
- implement `get_title` to show month and formatted net income

## Testing
- `python -m black payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history_child/annual_payroll_history_child.py`
- `python -m isort payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history_child/annual_payroll_history_child.py` *(no output)*
- `PYTHONPATH=/tmp:$PYTHONPATH pytest` *(fails: ModuleNotFoundError: No module named 'frappe.model'; 'frappe' is not a package)*
- `pip install frappe` *(fails: Could not find a version that satisfies the requirement frappe)*

------
https://chatgpt.com/codex/tasks/task_e_688d90578bb0832cbbbbb624efb94b5b