### PR TITLE
feat: set bulan on monthly detail add

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.js
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.js
@@ -24,6 +24,10 @@ frappe.ui.form.on('Annual Payroll History Child', {
         calculate_totals(frm);
     },
     monthly_details_add: function(frm, cdt, cdn) {
+        // set "bulan" to the current length of monthly_details when a row is added
+        if (frm.doc.monthly_details) {
+            frappe.model.set_value(cdt, cdn, 'bulan', frm.doc.monthly_details.length);
+        }
         calculate_totals(frm);
     },
     monthly_details_remove: function(frm, cdt, cdn) {


### PR DESCRIPTION
## Summary
- auto-set `bulan` when adding monthly details

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*


------
https://chatgpt.com/codex/tasks/task_e_688d91696238832cbc0e78a79fdc2f49