### PR TITLE
feat: add month-based payroll history records

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,57 @@
+import sys
+import types
+import datetime
+
+frappe = types.ModuleType("frappe")
+
+class DummyLogger:
+    def info(self, *args, **kwargs):
+        pass
+    def warning(self, *args, **kwargs):
+        pass
+    def error(self, *args, **kwargs):
+        pass
+    def debug(self, *args, **kwargs):
+        pass
+
+frappe.logger = lambda *a, **k: DummyLogger()
+frappe.get_doc = lambda *a, **k: {}
+frappe.throw = lambda *a, **k: None
+frappe.ValidationError = type("ValidationError", (Exception,), {})
+frappe.LinkValidationError = type("LinkValidationError", (Exception,), {})
+frappe.log_error = lambda *a, **k: None
+frappe.db = types.SimpleNamespace(get_value=lambda *a, **k: None)
+frappe.new_doc = lambda *a, **k: types.SimpleNamespace(
+    set=lambda self, name, value: setattr(self, name, value),
+    append=lambda *a, **k: types.SimpleNamespace(set=lambda *a, **k: None),
+    is_new=lambda: True,
+    save=lambda *a, **k: None,
+    get=lambda *a, **k: None,
+    monthly_details=[],
+)
+frappe.get_hooks = lambda *a, **k: {}
+frappe.get_attr = lambda path: None
+
+utils = types.ModuleType("frappe.utils")
+utils.flt = lambda val, precision=None: float(val)
+utils.getdate = lambda val: datetime.datetime.strptime(str(val), "%Y-%m-%d")
+utils.now = lambda: "2024-01-01 00:00:00"
+
+safe_exec_mod = types.ModuleType("frappe.utils.safe_exec")
+safe_exec_mod.safe_eval = lambda expr, context=None: eval(expr, context or {})
+
+frappe.utils = utils
+frappe.session = types.SimpleNamespace(user="test")
+
+sys.modules.setdefault("frappe", frappe)
+sys.modules.setdefault("frappe.utils", utils)
+sys.modules.setdefault("frappe.utils.safe_exec", safe_exec_mod)
+model_mod = types.ModuleType("frappe.model")
+document_mod = types.ModuleType("frappe.model.document")
+document_mod.Document = type("Document", (object,), {})
+model_mod.document = document_mod
+sys.modules.setdefault("frappe.model", model_mod)
+sys.modules.setdefault("frappe.model.document", document_mod)
+payroll_entry_mod = types.ModuleType("hrms.payroll.doctype.payroll_entry.payroll_entry")
+payroll_entry_mod.PayrollEntry = type("PayrollEntry", (object,), {})
+sys.modules.setdefault("hrms.payroll.doctype.payroll_entry.payroll_entry", payroll_entry_mod)

--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -599,6 +599,7 @@ class CustomSalarySlip(SalarySlip):
                 sync_annual_payroll_history.sync_annual_payroll_history(
                     employee=employee_doc,
                     fiscal_year=fiscal_year,
+                    month=month_number,
                     monthly_results=[monthly_result],
                     summary=None,
                 )
@@ -617,6 +618,7 @@ class CustomSalarySlip(SalarySlip):
                 sync_annual_payroll_history.sync_annual_payroll_history(
                     employee=employee_doc,
                     fiscal_year=fiscal_year,
+                    month=month_number,
                     monthly_results=[monthly_result],
                     summary=summary,
                 )
@@ -660,10 +662,18 @@ class CustomSalarySlip(SalarySlip):
                     f"Could not determine fiscal year for cancelled Salary Slip {self.name}, skipping sync"
                 )
                 return
-                
+            month_number = 0
+            start = getattr(self, "start_date", None)
+            if start:
+                try:
+                    month_number = getdate(start).month
+                except Exception:
+                    month_number = 0
+
             sync_annual_payroll_history.sync_annual_payroll_history(
                 employee=employee_doc,
                 fiscal_year=fiscal_year,
+                month=month_number,
                 monthly_results=None,
                 summary=None,
                 cancelled_salary_slip=self.name,

--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.json
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.json
@@ -9,6 +9,7 @@
   "is_creatable": 1,
   "show_in_module_section": 1,
   "route": "annual-payroll-history",
+  "autoname": "field:employee-field:month",
   "fields": [
     {
       "fieldname": "fiscal_year",
@@ -22,6 +23,13 @@
       "fieldtype": "Link",
       "label": "Employee",
       "options": "Employee",
+      "reqd": 1,
+      "in_list_view": 1
+    },
+    {
+      "fieldname": "month",
+      "fieldtype": "Int",
+      "label": "Month",
       "reqd": 1,
       "in_list_view": 1
     },

--- a/payroll_indonesia/tests/test_annual_payroll_history.py
+++ b/payroll_indonesia/tests/test_annual_payroll_history.py
@@ -1,0 +1,30 @@
+import types
+import sys
+
+
+def test_get_or_create_creates_with_month(monkeypatch):
+    frappe = sys.modules.get("frappe")
+
+    from payroll_indonesia.utils.sync_annual_payroll_history import (
+        get_or_create_annual_payroll_history,
+    )
+
+    doc = get_or_create_annual_payroll_history("EMP001", "2024", 5)
+    assert doc.name == "EMP001-5"
+    assert doc.month == 5
+    assert doc.fiscal_year == "2024"
+
+
+def test_get_or_create_returns_existing(monkeypatch):
+    frappe = sys.modules.get("frappe")
+
+    from payroll_indonesia.utils.sync_annual_payroll_history import (
+        get_or_create_annual_payroll_history,
+    )
+
+    existing = types.SimpleNamespace(name="EMP001-5")
+    frappe.get_doc = lambda dt, name: existing
+    frappe.db.get_value = lambda dt, filters, field: "EMP001-5"
+
+    doc = get_or_create_annual_payroll_history("EMP001", "2024", 5)
+    assert doc is existing

--- a/payroll_indonesia/tests/test_salary_slip_sync_once.py
+++ b/payroll_indonesia/tests/test_salary_slip_sync_once.py
@@ -20,7 +20,7 @@ def test_salary_slip_validate_submit_sync_once(monkeypatch):
         def error(self, msg):
             pass
 
-    frappe.logger = lambda: DummyLogger()
+    frappe.logger = lambda *a, **k: DummyLogger()
     frappe.get_doc = lambda *args, **kwargs: {}
     frappe.throw = lambda *args, **kwargs: None
     frappe.ValidationError = type("ValidationError", (Exception,), {})


### PR DESCRIPTION
## Summary
- track annual payroll history per employee and month
- include month in payroll history syncing and naming
- cover month-based naming with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d9264730c832cb0c9a40d331058ed