### PR TITLE
chore: clean workspace reports

### DIFF
--- a/payroll_indonesia/fixtures/workspace.json
+++ b/payroll_indonesia/fixtures/workspace.json
@@ -36,7 +36,7 @@
       "links": [
         {
           "label": "Employee",
-          "link_to": "Employee", 
+          "link_to": "Employee",
           "type": "DocType"
         },
         {
@@ -130,23 +130,13 @@
           "type": "Report"
         },
         {
-          "label": "Tax Report",
+          "label": "PPh21 Report",
           "link_to": "PPh21 Report",
           "type": "Report"
         },
         {
           "label": "BPJS Report",
           "link_to": "BPJS Report",
-          "type": "Report"
-        }
-      ]
-    },
-    {
-      "label": "Deduction Reports",
-      "links": [
-        {
-          "label": "Employee Deduction Summary",
-          "link_to": "Employee Deduction Summary",
           "type": "Report"
         }
       ]


### PR DESCRIPTION
## Summary
- update workspace report link from `Tax Report` to `PPh21 Report`
- drop unused `Deduction Reports` card referencing `Employee Deduction Summary`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d9da36b34832cad56072e38f9406c