### PR TITLE
Guard annual history sync against duplicate calls

### DIFF
--- a/payroll_indonesia/tests/test_salary_slip_sync_once.py
+++ b/payroll_indonesia/tests/test_salary_slip_sync_once.py
@@ -55,7 +55,15 @@ def test_salary_slip_validate_submit_sync_once(monkeypatch):
             "rate": 0,
             "pph21": 0,
         }
-        self.sync_to_annual_payroll_history(result, mode="monthly")
+        if not getattr(self, "_annual_history_synced", False):
+            self._annual_history_synced = True
+            _ok = False
+            try:
+                self.sync_to_annual_payroll_history(result, mode="monthly")
+                _ok = True
+            finally:
+                if not _ok:
+                    self._annual_history_synced = False
         return 0
 
     monkeypatch.setattr(CustomSalarySlip, "calculate_income_tax", fake_calc, raising=False)


### PR DESCRIPTION
## Summary
- prevent duplicate Annual Payroll History syncs by setting `_annual_history_synced` before sync and clearing it if the sync fails
- move `_annual_history_synced` handling out of `sync_to_annual_payroll_history`
- adjust tests to reflect new flag logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688db7add56c832c815ca2e195e6ec28