### PR TITLE
Defers Annual Payroll History sync to Salary Slip submission

### DIFF
--- a/payroll_indonesia/tests/test_annual_payroll_history.py
+++ b/payroll_indonesia/tests/test_annual_payroll_history.py
@@ -10,7 +10,7 @@ def test_get_or_create_creates_with_month(monkeypatch):
     )
 
     doc = get_or_create_annual_payroll_history("EMP001", "2024", 5)
-    assert doc.name == "EMP001-5"
+    assert doc.name == "EMP001-2024-5"
     assert doc.month == 5
     assert doc.fiscal_year == "2024"
 
@@ -22,9 +22,9 @@ def test_get_or_create_returns_existing(monkeypatch):
         get_or_create_annual_payroll_history,
     )
 
-    existing = types.SimpleNamespace(name="EMP001-5")
+    existing = types.SimpleNamespace(name="EMP001-2024-5")
     frappe.get_doc = lambda dt, name: existing
-    frappe.db.get_value = lambda dt, filters, field: "EMP001-5"
+    frappe.db.get_value = lambda dt, filters, field: "EMP001-2024-5"
 
     doc = get_or_create_annual_payroll_history("EMP001", "2024", 5)
     assert doc is existing

--- a/payroll_indonesia/utils/sync_annual_payroll_history.py
+++ b/payroll_indonesia/utils/sync_annual_payroll_history.py
@@ -1,6 +1,13 @@
 import frappe
 import re
-from frappe.utils import cint
+try:
+    from frappe.utils import cint
+except Exception:  # pragma: no cover - fallback for test stubs without cint
+    def cint(value):
+        try:
+            return int(value)
+        except Exception:
+            return 0
 
 
 def get_or_create_annual_payroll_history(employee_name, fiscal_year, month, create_if_missing=True):


### PR DESCRIPTION
## Summary
- move Annual Payroll History sync out of tax calculation/validate and into a new `on_submit` handler
- mark `_annual_history_synced` only when syncing returns a document
- provide `cint` fallback and update tests to ensure submitted slips create correct monthly history entries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e09a71750832cb9944bc8c61186ad