### PR TITLE
feat: persist error state in annual history sync

### DIFF
--- a/payroll_indonesia/tests/test_sync_error_state.py
+++ b/payroll_indonesia/tests/test_sync_error_state.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import types
+import importlib
+import json
+
+
+def test_sync_error_state_forces_save(monkeypatch):
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+    frappe = types.SimpleNamespace()
+
+    class DummyLogger:
+        def info(self, msg):
+            pass
+
+        def warning(self, msg):
+            pass
+
+        def debug(self, msg):
+            pass
+
+    frappe.logger = lambda *a, **k: DummyLogger()
+    frappe.throw = lambda *a, **k: None
+    frappe.log_error = lambda *a, **k: None
+    frappe.db = types.SimpleNamespace(savepoint=lambda name: None, rollback=lambda save_point=None: None)
+    frappe.utils = types.SimpleNamespace(now=lambda: "now")
+    frappe.as_json = json.dumps
+    frappe.session = types.SimpleNamespace(user="tester")
+
+    sys.modules["frappe"] = frappe
+    sys.modules["frappe.utils"] = frappe.utils
+
+    if "payroll_indonesia.utils.sync_annual_payroll_history" in sys.modules:
+        del sys.modules["payroll_indonesia.utils.sync_annual_payroll_history"]
+    sync_mod = importlib.import_module("payroll_indonesia.utils.sync_annual_payroll_history")
+
+    class HistoryDoc:
+        def __init__(self):
+            self.name = "APH-1"
+            self.flags = types.SimpleNamespace()
+            self.saved = False
+
+        def is_new(self):
+            return False
+
+        def get(self, key, default=None):
+            return getattr(self, key, default)
+
+        def set(self, key, value):
+            setattr(self, key, value)
+
+        def save(self):
+            self.saved = True
+
+    doc = HistoryDoc()
+    monkeypatch.setattr(sync_mod, "get_or_create_annual_payroll_history", lambda *a, **k: doc)
+
+    result = sync_mod.sync_annual_payroll_history(
+        employee={"name": "EMP1"},
+        fiscal_year="2024",
+        month=5,
+        error_state={"detail": "failure"},
+    )
+
+    assert result == "APH-1"
+    assert doc.saved
+    assert doc.error_state == json.dumps({"detail": "failure"})
+


### PR DESCRIPTION
## Summary
- handle optional error_state in sync_annual_payroll_history
- test to ensure error_state forces save

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e0b35b55c832ca53cd41ad268b2dc