### PR TITLE
refactor: remove month field from Annual Payroll History

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.json
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.json
@@ -9,7 +9,7 @@
   "is_creatable": 1,
   "show_in_module_section": 1,
   "route": "annual-payroll-history",
-  "autoname": "field:employee-field:month",
+  "autoname": "field:employee-field:fiscal_year",
   "fields": [
     {
       "fieldname": "fiscal_year",
@@ -23,13 +23,6 @@
       "fieldtype": "Link",
       "label": "Employee",
       "options": "Employee",
-      "reqd": 1,
-      "in_list_view": 1
-    },
-    {
-      "fieldname": "month",
-      "fieldtype": "Int",
-      "label": "Month",
       "reqd": 1,
       "in_list_view": 1
     },

--- a/payroll_indonesia/tests/test_annual_payroll_history.py
+++ b/payroll_indonesia/tests/test_annual_payroll_history.py
@@ -2,16 +2,15 @@ import types
 import sys
 
 
-def test_get_or_create_creates_with_month(monkeypatch):
+def test_get_or_create_creates(monkeypatch):
     frappe = sys.modules.get("frappe")
 
     from payroll_indonesia.utils.sync_annual_payroll_history import (
         get_or_create_annual_payroll_history,
     )
 
-    doc = get_or_create_annual_payroll_history("EMP001", "2024", 5)
-    assert doc.name == "EMP001-2024-5"
-    assert doc.month == 5
+    doc = get_or_create_annual_payroll_history("EMP001", "2024")
+    assert doc.name == "EMP001-2024"
     assert doc.fiscal_year == "2024"
 
 
@@ -22,9 +21,9 @@ def test_get_or_create_returns_existing(monkeypatch):
         get_or_create_annual_payroll_history,
     )
 
-    existing = types.SimpleNamespace(name="EMP001-2024-5")
+    existing = types.SimpleNamespace(name="EMP001-2024")
     frappe.get_doc = lambda dt, name: existing
-    frappe.db.get_value = lambda dt, filters, field: "EMP001-2024-5"
+    frappe.db.get_value = lambda dt, filters, field: "EMP001-2024"
 
-    doc = get_or_create_annual_payroll_history("EMP001", "2024", 5)
+    doc = get_or_create_annual_payroll_history("EMP001", "2024")
     assert doc is existing

--- a/payroll_indonesia/utils/sync_annual_payroll_history.py
+++ b/payroll_indonesia/utils/sync_annual_payroll_history.py
@@ -10,8 +10,8 @@ except Exception:  # pragma: no cover - fallback for test stubs without cint
             return 0
 
 
-def get_or_create_annual_payroll_history(employee_name, fiscal_year, month, create_if_missing=True):
-    """Ambil doc Annual Payroll History berdasarkan employee, fiscal_year, dan month.
+def get_or_create_annual_payroll_history(employee_name, fiscal_year, create_if_missing=True):
+    """Ambil doc Annual Payroll History berdasarkan ``employee`` dan ``fiscal_year``.
 
     Jika tidak ada dan ``create_if_missing`` bernilai ``True`` akan membuat doc baru.
     Bila ``create_if_missing`` ``False`` dan dokumen tidak ditemukan, kembalikan ``None``.
@@ -19,7 +19,7 @@ def get_or_create_annual_payroll_history(employee_name, fiscal_year, month, crea
     # Menggunakan frappe.db.exists untuk pengecekan cepat keberadaan dokumen
     doc_name = frappe.db.get_value(
         "Annual Payroll History",
-        {"employee": employee_name, "fiscal_year": fiscal_year, "month": month},
+        {"employee": employee_name, "fiscal_year": fiscal_year},
         "name"
     )
     
@@ -33,12 +33,11 @@ def get_or_create_annual_payroll_history(employee_name, fiscal_year, month, crea
     history = frappe.new_doc("Annual Payroll History")
     history.employee = employee_name
     history.fiscal_year = fiscal_year
-    history.month = month
 
-    # Set name ke kombinasi unik employee-fiscal_year-month jika skema doctype mendukung
+    # Set name ke kombinasi unik employee-fiscal_year jika skema doctype mendukung
     # Catatan: Ini hanya akan berhasil jika Annual Payroll History DocType dikonfigurasi
-    # untuk menerima nama kustom (autoname: field:employee-field:fiscal_year-field:month atau prompt)
-    history.name = f"{employee_name}-{fiscal_year}-{month}"
+    # untuk menerima nama kustom (autoname: field:employee-field:fiscal_year atau prompt)
+    history.name = f"{employee_name}-{fiscal_year}"
     
     return history
 
@@ -183,7 +182,7 @@ def sync_annual_payroll_history(
     Fungsi ini menggunakan frappe.db.savepoint() untuk penanganan transaksi, namun
     tidak melakukan commit. Pemanggil harus mengelola commit/rollback sesuai kebutuhan.
 
-    - Jika dokumen sudah ada untuk employee & fiscal_year & month, update.
+    - Jika dokumen sudah ada untuk employee & fiscal_year, update.
     - Jika belum ada, create baru.
     - Jika salary_slip dicancel, hapus baris terkait pada child.
     - Perubahan akan di-rollback jika terjadi error setelah savepoint.
@@ -263,13 +262,13 @@ def sync_annual_payroll_history(
 
     try:
         history = get_or_create_annual_payroll_history(
-            employee_name, fiscal_year, month, create_if_missing=not only_cancel
+            employee_name, fiscal_year, create_if_missing=not only_cancel
         )
 
         if not history:
             frappe.logger().info(
                 f"No Annual Payroll History found for employee {employee_name}, "
-                f"fiscal year {fiscal_year}, month {month} and not creating new record"
+                f"fiscal year {fiscal_year} and not creating new record"
             )
             return None
 


### PR DESCRIPTION
## Summary
- remove `month` field from Annual Payroll History and rely on employee/fiscal year naming
- adjust sync utility to work without parent month field
- update tests for new Annual Payroll History schema

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e15260a94832c8bff7c3629c29886