### PR TITLE
feat: add multi-month annual payroll sync

### DIFF
--- a/payroll_indonesia/override/payroll_entry.py
+++ b/payroll_indonesia/override/payroll_entry.py
@@ -342,7 +342,6 @@ class CustomPayrollEntry(PayrollEntry):
                             sync_annual_payroll_history.sync_annual_payroll_history(
                                 employee=employee_doc,
                                 fiscal_year=fiscal_year,
-                                month=month_number,
                                 monthly_results=None,
                                 summary=None,
                                 cancelled_salary_slip=name,

--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -594,7 +594,6 @@ class CustomSalarySlip(SalarySlip):
                 docname = sync_annual_payroll_history.sync_annual_payroll_history(
                     employee=employee_doc,
                     fiscal_year=fiscal_year,
-                    month=month_number,
                     monthly_results=[monthly_result],
                     summary=None,
                 )
@@ -613,7 +612,6 @@ class CustomSalarySlip(SalarySlip):
                 docname = sync_annual_payroll_history.sync_annual_payroll_history(
                     employee=employee_doc,
                     fiscal_year=fiscal_year,
-                    month=month_number,
                     monthly_results=[monthly_result],
                     summary=summary,
                 )
@@ -677,7 +675,6 @@ class CustomSalarySlip(SalarySlip):
             sync_annual_payroll_history.sync_annual_payroll_history(
                 employee=employee_doc,
                 fiscal_year=fiscal_year,
-                month=month_number,
                 monthly_results=None,
                 summary=None,
                 cancelled_salary_slip=self.name,

--- a/payroll_indonesia/tests/test_sync_error_state.py
+++ b/payroll_indonesia/tests/test_sync_error_state.py
@@ -59,7 +59,6 @@ def test_sync_error_state_forces_save(monkeypatch):
     result = sync_mod.sync_annual_payroll_history(
         employee={"name": "EMP1"},
         fiscal_year="2024",
-        month=5,
         error_state={"detail": "failure"},
     )
 


### PR DESCRIPTION
## Summary
- add new `sync_annual_payroll_history` that syncs all provided months
- keep legacy per-month sync via `sync_annual_payroll_history_for_month`
- update salary slip and payroll entry hooks to use new API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e1683ce28832ca4d8f627dccd3156