### PR TITLE
Simplify Annual Payroll History naming

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.json
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.json
@@ -9,7 +9,7 @@
   "is_creatable": 1,
   "show_in_module_section": 1,
   "route": "annual-payroll-history",
-  "autoname": "field:employee-field:fiscal_year",
+  "autoname": "format:{employee}-{fiscal_year}",
   "fields": [
     {
       "fieldname": "fiscal_year",

--- a/payroll_indonesia/tests/test_annual_payroll_history.py
+++ b/payroll_indonesia/tests/test_annual_payroll_history.py
@@ -10,7 +10,8 @@ def test_get_or_create_creates(monkeypatch):
     )
 
     doc = get_or_create_annual_payroll_history("EMP001", "2024")
-    assert doc.name == "EMP001-2024"
+    expected_name = "-".join(["EMP001", "2024"])
+    assert doc.name == expected_name
     assert doc.fiscal_year == "2024"
 
 
@@ -21,9 +22,10 @@ def test_get_or_create_returns_existing(monkeypatch):
         get_or_create_annual_payroll_history,
     )
 
-    existing = types.SimpleNamespace(name="EMP001-2024")
+    expected_name = "-".join(["EMP001", "2024"])
+    existing = types.SimpleNamespace(name=expected_name)
     frappe.get_doc = lambda dt, name: existing
-    frappe.db.get_value = lambda dt, filters, field: "EMP001-2024"
+    frappe.db.get_value = lambda dt, filters, field: expected_name
 
     doc = get_or_create_annual_payroll_history("EMP001", "2024")
     assert doc is existing

--- a/payroll_indonesia/utils/sync_annual_payroll_history.py
+++ b/payroll_indonesia/utils/sync_annual_payroll_history.py
@@ -36,7 +36,7 @@ def get_or_create_annual_payroll_history(employee_name, fiscal_year, create_if_m
 
     # Set name ke kombinasi unik employee-fiscal_year jika skema doctype mendukung
     # Catatan: Ini hanya akan berhasil jika Annual Payroll History DocType dikonfigurasi
-    # untuk menerima nama kustom (autoname: field:employee-field:fiscal_year atau prompt)
+    # untuk menerima nama kustom (autoname: format:{employee}-{fiscal_year} atau prompt)
     history.name = f"{employee_name}-{fiscal_year}"
     
     return history


### PR DESCRIPTION
## Summary
- use employee and fiscal year to name Annual Payroll History docs
- document the new naming scheme in sync helper
- adjust tests for the new naming format

## Testing
- `pytest`
- `pip install pre-commit pytest` *(failed: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_688e183d785c832c89f613f231390e18