### PR TITLE
Use Indonesian bulan terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Ganti seluruh referensi `month` menjadi `bulan` atau `fiscal_year`.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Penjelasan mengenai kelas `CustomSalarySlip` beserta cara mengaktifkan override 
 
 ---
 
+## Changelog
+
+Lihat [CHANGELOG.md](CHANGELOG.md) untuk daftar perubahan.
+
+---
+
 ## Lisensi
 
 MIT License

--- a/payroll_indonesia/config/pph21_progressive.py
+++ b/payroll_indonesia/config/pph21_progressive.py
@@ -139,7 +139,7 @@ def calculate_pph21_progressive_year(employee, salary_slips, pph21_paid_jan_nov=
             'pkp_annual': float,
             'rate': str,       # range progresif
             'pph21_annual': float,
-            'pph21_month': float,
+            'pph21_bulan': float,
             'income_tax_deduction_total': float,
             'biaya_jabatan_total': float,
             'koreksi_pph21': float,
@@ -160,7 +160,7 @@ def calculate_pph21_progressive_year(employee, salary_slips, pph21_paid_jan_nov=
             "pkp_annual": 0.0,
             "rate": "",
             "pph21_annual": 0.0,
-            "pph21_month": 0.0,
+            "pph21_bulan": 0.0,
             "income_tax_deduction_total": 0.0,
             "biaya_jabatan_total": 0.0,
             "koreksi_pph21": 0.0,
@@ -196,9 +196,9 @@ def calculate_pph21_progressive_year(employee, salary_slips, pph21_paid_jan_nov=
     # 5. Pajak bulan Desember/final
     koreksi_pph21 = pph21_annual - pph21_paid_jan_nov
     if koreksi_pph21 > 0:
-        pph21_month = koreksi_pph21
+        pph21_bulan = koreksi_pph21
     else:
-        pph21_month = 0
+        pph21_bulan = 0
 
     # 6. Rate info (for audit only)
     rates = "/".join([f"{rate}%" for _, rate in get_tax_slabs()])
@@ -210,7 +210,7 @@ def calculate_pph21_progressive_year(employee, salary_slips, pph21_paid_jan_nov=
         "pkp_annual": pkp_annual,
         "rate": rates,
         "pph21_annual": pph21_annual,
-        "pph21_month": pph21_month,
+        "pph21_bulan": pph21_bulan,
         "income_tax_deduction_total": income_tax_deduction_total,
         "biaya_jabatan_total": biaya_jabatan_total,
         "koreksi_pph21": koreksi_pph21,

--- a/payroll_indonesia/config/pph21_ter.py
+++ b/payroll_indonesia/config/pph21_ter.py
@@ -33,10 +33,10 @@ PENGURANG_NETTO_NAMES = {
     "dana pensiun",
 }
 
-def calculate_pph21_TER(taxable_income: Union[float, Dict[str, Any]], 
-                        employee: Union[Dict[str, Any], Any], 
-                        company: str, 
-                        month: int = None) -> Dict[str, Any]:
+def calculate_pph21_TER(taxable_income: Union[float, Dict[str, Any]],
+                        employee: Union[Dict[str, Any], Any],
+                        company: str,
+                        bulan: int = None) -> Dict[str, Any]:
     """
     Calculate monthly PPh21 using TER (Tabel Pajak Bulanan) method.
     
@@ -44,7 +44,7 @@ def calculate_pph21_TER(taxable_income: Union[float, Dict[str, Any]],
         taxable_income: Either the gross income value or a dict containing slip data
         employee: Employee document or dictionary with employee data
         company: Company name or ID
-        month: Month number (1-12), optional if provided in taxable_income
+        bulan: Nomor bulan (1-12), optional if provided in taxable_income
         
     Returns:
         Dictionary with calculation results including pph21 amount
@@ -63,25 +63,25 @@ def calculate_pph21_TER(taxable_income: Union[float, Dict[str, Any]],
     slip_data = None
     if isinstance(taxable_income, dict) and taxable_income.get("earnings") is not None:
         slip_data = taxable_income
-        # Extract month from slip if not provided
-        if not month and slip_data.get("start_date"):
+        # Extract bulan from slip if not provided
+        if not bulan and slip_data.get("start_date"):
             try:
                 from frappe.utils import getdate
-                month = getdate(slip_data.get("start_date")).month
+                bulan = getdate(slip_data.get("start_date")).month
             except Exception:
                 pass
-    
-    # Ensure month is valid or use default
-    if not month:
-        # Try to get month from employee data
-        if hasattr(employee, "month"):
-            month = employee.month
-        elif isinstance(employee, dict) and employee.get("month"):
-            month = employee.get("month")
+
+    # Ensure bulan is valid or use default
+    if not bulan:
+        # Try to get bulan from employee data
+        if hasattr(employee, "bulan"):
+            bulan = getattr(employee, "bulan")
+        elif isinstance(employee, dict) and employee.get("bulan"):
+            bulan = employee.get("bulan")
         else:
-            # Default to current month if not provided
+            # Default ke bulan berjalan jika tidak diberikan
             from datetime import datetime
-            month = datetime.now().month
+            bulan = datetime.now().month
     
     # Employment type check - only process Full-time employees
     emp_type = employee.get("employment_type") if isinstance(employee, dict) else getattr(employee, "employment_type", None)

--- a/payroll_indonesia/config/pph21_ter_december.py
+++ b/payroll_indonesia/config/pph21_ter_december.py
@@ -37,7 +37,7 @@ def calculate_pph21_december(
     Calculate December PPh21 using progressive rates (annual correction).
     
     Args:
-        taxable_income: December month taxable income
+        taxable_income: Pendapatan kena pajak bulan Desember
         employee: Employee document or dictionary with employee data
         company: Company name or ID
         ytd_income: Year-to-date income including December
@@ -66,7 +66,7 @@ def calculate_pph21_december(
             "pkp_annual": 0.0,
             "rate": "",
             "pph21_annual": 0.0,
-            "pph21_month": 0.0,
+            "pph21_bulan": 0.0,
             "income_tax_deduction_total": 0.0,
             "biaya_jabatan_total": 0.0,
             "koreksi_pph21": 0.0,
@@ -91,7 +91,7 @@ def calculate_pph21_december(
     koreksi_pph21 = pph21_annual - ytd_tax_paid
     
     # December PPh21 is the positive correction amount (negative means refund, handled separately)
-    pph21_month_des = koreksi_pph21 if koreksi_pph21 > 0 else 0
+    pph21_bulan_des = koreksi_pph21 if koreksi_pph21 > 0 else 0
     
     # Get tax rates description
     rates = "/".join([f"{rate}%" for _, rate in get_tax_slabs()])
@@ -104,7 +104,7 @@ def calculate_pph21_december(
         "pkp_annual": pkp_annual,
         "rate": rates,
         "pph21_annual": pph21_annual,
-        "pph21_month": pph21_month_des,
+        "pph21_bulan": pph21_bulan_des,
         "income_tax_deduction_total": 0.0,  # Would need actual deduction data
         "biaya_jabatan_total": 0.0,  # Would need actual biaya jabatan data
         "koreksi_pph21": koreksi_pph21,
@@ -152,7 +152,7 @@ def calculate_pph21_december_from_slips(
             "pkp_annual": 0.0,
             "rate": "",
             "pph21_annual": 0.0,
-            "pph21_month": 0.0,
+            "pph21_bulan": 0.0,
             "income_tax_deduction_total": 0.0,
             "biaya_jabatan_total": 0.0,
             "koreksi_pph21": 0.0,
@@ -166,26 +166,26 @@ def calculate_pph21_december_from_slips(
     biaya_jabatan_total = 0.0
     pph21_paid_jan_nov = 0.0
     
-    # Extract month 12 slip if it exists
+    # Pisahkan slip bulan Desember jika ada
     december_slip = None
     jan_nov_slips = []
-    
+
     for slip in salary_slips:
-        # Try to determine the month
-        month = None
+        # Coba tentukan bulan dari tanggal mulai
+        bulan = None
         if slip.get("start_date"):
             try:
                 from frappe.utils import getdate
-                month = getdate(slip.get("start_date")).month
+                bulan = getdate(slip.get("start_date")).month
             except Exception:
                 pass
-        
-        # If we can identify month 12, separate it
-        if month == 12:
+
+        # Jika teridentifikasi bulan 12, pisahkan
+        if bulan == 12:
             december_slip = slip
             continue
-        
-        # Add to Jan-Nov list
+
+        # Tambahkan ke daftar Jan-Nov
         jan_nov_slips.append(slip)
         
         # Process Jan-Nov slips for totals
@@ -220,7 +220,7 @@ def calculate_pph21_december_from_slips(
     koreksi_pph21 = pph21_annual - pph21_paid_jan_nov
     
     # December PPh21
-    pph21_month_des = koreksi_pph21 if koreksi_pph21 > 0 else 0
+    pph21_bulan_des = koreksi_pph21 if koreksi_pph21 > 0 else 0
     
     # Get tax rates description
     rates = "/".join([f"{rate}%" for _, rate in get_tax_slabs()])
@@ -233,7 +233,7 @@ def calculate_pph21_december_from_slips(
         "pkp_annual": pkp_annual,
         "rate": rates,
         "pph21_annual": pph21_annual,
-        "pph21_month": pph21_month_des,
+        "pph21_bulan": pph21_bulan_des,
         "income_tax_deduction_total": pengurang_netto_total,
         "biaya_jabatan_total": biaya_jabatan_total,
         "koreksi_pph21": koreksi_pph21,

--- a/payroll_indonesia/override/payroll_entry.py
+++ b/payroll_indonesia/override/payroll_entry.py
@@ -324,21 +324,6 @@ class CustomPayrollEntry(PayrollEntry):
                         
                         # If we have the necessary data, clean up the history entry
                         if fiscal_year:
-                            # Get month number
-                            month_number = 0
-                            if hasattr(slip_obj, "_get_month_number") and callable(getattr(slip_obj, "_get_month_number")):
-                                month_number = slip_obj._get_month_number(
-                                    start_date=getattr(slip_obj, "start_date", None),
-                                    month_name=getattr(slip_obj, "month", None) or getattr(slip_obj, "bulan", None)
-                                )
-                            elif hasattr(slip_obj, "start_date") and slip_obj.start_date:
-                                try:
-                                    from frappe.utils import getdate
-                                    month_number = getdate(slip_obj.start_date).month
-                                except Exception:
-                                    month_number = 0
-                            
-                            # Call sync function with cancelled_salary_slip parameter
                             sync_annual_payroll_history.sync_annual_payroll_history(
                                 employee=employee_doc,
                                 fiscal_year=fiscal_year,


### PR DESCRIPTION
## Summary
- replace month-based parameters with Indonesian `bulan`
- rename PPh21 monthly keys to `pph21_bulan`
- document bulan usage and add changelog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e1b202fac832c80ce2fc7597efd00