### PR TITLE
feat: add error state to monthly payroll detail

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history_child/annual_payroll_history_child.json
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history_child/annual_payroll_history_child.json
@@ -67,6 +67,13 @@
       "label": "Salary Slip",
       "in_list_view": 1,
       "options": "Salary Slip"
+    },
+    {
+      "fieldname": "error_state",
+      "fieldtype": "Small Text",
+      "label": "Error State",
+      "collapsible": 1,
+      "description": "JSON error bila salary slip gagal diproses"
     }
   ],
   "modified": "2024-01-01 00:00:00"

--- a/payroll_indonesia/tests/test_upsert_monthly_detail.py
+++ b/payroll_indonesia/tests/test_upsert_monthly_detail.py
@@ -1,0 +1,32 @@
+import sys
+import types
+
+
+def test_upsert_monthly_detail_handles_error_state(monkeypatch):
+    sys.modules['frappe'] = types.SimpleNamespace()
+    from payroll_indonesia.utils.sync_annual_payroll_history import upsert_monthly_detail
+
+    class Row:
+        def set(self, key, value):
+            setattr(self, key, value)
+
+    class HistoryDoc:
+        def __init__(self):
+            self.monthly_details = []
+
+        def get(self, key, default=None):
+            return getattr(self, key, default)
+
+        def append(self, key, value):
+            assert key == 'monthly_details'
+            row = Row()
+            self.monthly_details.append(row)
+            return row
+
+    history = HistoryDoc()
+
+    assert upsert_monthly_detail(history, {'bulan': 1, 'error_state': 'oops'})
+    assert history.monthly_details[0].error_state == 'oops'
+
+    assert upsert_monthly_detail(history, {'bulan': 1, 'error_state': 'new'})
+    assert history.monthly_details[0].error_state == 'new'

--- a/payroll_indonesia/utils/sync_annual_payroll_history.py
+++ b/payroll_indonesia/utils/sync_annual_payroll_history.py
@@ -132,13 +132,35 @@ def upsert_monthly_detail(history, month_data):
     if found:
         # Update existing record
         for k, v in month_data.items():
-            if k in ["bulan", "bruto", "pengurang_netto", "biaya_jabatan", "netto", "pkp", "rate", "pph21", "salary_slip"]:
+            if k in [
+                "bulan",
+                "bruto",
+                "pengurang_netto",
+                "biaya_jabatan",
+                "netto",
+                "pkp",
+                "rate",
+                "pph21",
+                "salary_slip",
+                "error_state",
+            ]:
                 found.set(k, v)
     else:
         # Create new record
         detail = history.append("monthly_details", {})
         for k, v in month_data.items():
-            if k in ["bulan", "bruto", "pengurang_netto", "biaya_jabatan", "netto", "pkp", "rate", "pph21", "salary_slip"]:
+            if k in [
+                "bulan",
+                "bruto",
+                "pengurang_netto",
+                "biaya_jabatan",
+                "netto",
+                "pkp",
+                "rate",
+                "pph21",
+                "salary_slip",
+                "error_state",
+            ]:
                 detail.set(k, v)
                 
     return True


### PR DESCRIPTION
## Summary
- add `error_state` Small Text field to Annual Payroll History Child DocType
- allow `upsert_monthly_detail` to update `error_state`
- test monthly detail updating `error_state`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e222d4908832caa9231b36f1e5e90