### PR TITLE
Ensure summary-only annual payroll sync persists totals

### DIFF
--- a/payroll_indonesia/utils/sync_annual_payroll_history.py
+++ b/payroll_indonesia/utils/sync_annual_payroll_history.py
@@ -422,10 +422,10 @@ def sync_annual_payroll_history_for_bulan(
         if error_state is not None:
             history.set("error_state", frappe.as_json(error_state))
 
-        # Skip saving only when no changes occurred and no error state recorded
-        if rows_updated == 0 and rows_deleted == 0 and error_state is None:
+        # Skip saving only when no changes occurred, no summary provided, and no error state recorded
+        if rows_updated == 0 and rows_deleted == 0 and error_state is None and not summary:
             frappe.logger().info(
-                f"No rows updated or deleted in Annual Payroll History for {employee_name}, skipping save"
+                f"No rows updated, deleted, or summary provided in Annual Payroll History for {employee_name}, skipping save"
             )
             return None
 


### PR DESCRIPTION
## Summary
- handle summary-only sync by checking summary flag before skipping save

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e3507b580832c8db9ff00a0c733ca