### PR TITLE
feat: add salary slip doc events

### DIFF
--- a/payroll_indonesia/hooks.py
+++ b/payroll_indonesia/hooks.py
@@ -126,7 +126,11 @@ salary_slip_globals = {
 doc_events = {
     "Salary Structure": {
         "validate": "payroll_indonesia.utils.validate_salary_structure.validate_salary_structure_required_components"
-    }
+    },
+    "Salary Slip": {
+        "on_submit": "payroll_indonesia.override.salary_slip.on_submit",
+        "on_cancel": "payroll_indonesia.override.salary_slip.on_cancel",
+    },
 }
 
 # Scheduled Tasks

--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -683,4 +683,24 @@ class CustomSalarySlip(SalarySlip):
                 title="Payroll Indonesia Annual History Cancel Error"
             )
             # History sync failures shouldn't stop slip cancellation, so we log but don't raise
-            logger.warning(f"Failed to update Annual Payroll History when cancelling {self.name}: {str(e)}")
+            logger.warning(
+                f"Failed to update Annual Payroll History when cancelling {self.name}: {str(e)}"
+            )
+
+
+def on_submit(doc, method=None):
+    """DocEvent wrapper to sync Annual Payroll History on submit."""
+    if isinstance(doc, CustomSalarySlip):
+        return
+
+    doc.__class__ = CustomSalarySlip
+    doc.on_submit()
+
+
+def on_cancel(doc, method=None):
+    """DocEvent wrapper to clean up Annual Payroll History on cancel."""
+    if isinstance(doc, CustomSalarySlip):
+        return
+
+    doc.__class__ = CustomSalarySlip
+    doc.on_cancel()


### PR DESCRIPTION
## Summary
- hook Salary Slip submit/cancel events to ensure Annual Payroll History sync
- add event wrappers that reuse CustomSalarySlip logic when override is skipped

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e3e01ce14832c8b33e455bd81f389