### PR TITLE
refactor: rename employee parameter

### DIFF
--- a/payroll_indonesia/tests/test_annual_payroll_history.py
+++ b/payroll_indonesia/tests/test_annual_payroll_history.py
@@ -20,7 +20,7 @@ def test_get_or_create_creates(monkeypatch):
         fake_make_autoname,
     )
 
-    doc = get_or_create_annual_payroll_history("EMP001", "2024")
+    doc = get_or_create_annual_payroll_history(employee_id="EMP001", fiscal_year="2024")
     assert doc.name == "AUTO-EMP001-2024"
     assert captured["key"] == "EMP001-2024"
     assert doc.fiscal_year == "2024"
@@ -51,6 +51,6 @@ def test_get_or_create_returns_existing(monkeypatch):
         fake_make_autoname,
     )
 
-    doc = get_or_create_annual_payroll_history("EMP001", "2024")
+    doc = get_or_create_annual_payroll_history(employee_id="EMP001", fiscal_year="2024")
     assert doc is existing
     assert calls["count"] == 0


### PR DESCRIPTION
## Summary
- rename get_or_create_annual_payroll_history to accept `employee_id`
- update sync_annual_payroll_history to use `employee_id`
- fix tests for new parameter name

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e4f27bce4832cb58fd157505a8d49