### PR TITLE
feat: capture company on annual payroll history

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.json
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.json
@@ -19,6 +19,13 @@
       "reqd": 1
     },
     {
+      "fieldname": "company",
+      "fieldtype": "Link",
+      "label": "Company",
+      "options": "Company",
+      "reqd": 1
+    },
+    {
       "fieldname": "employee",
       "fieldtype": "Link",
       "label": "Employee",

--- a/payroll_indonesia/tests/test_annual_payroll_history.py
+++ b/payroll_indonesia/tests/test_annual_payroll_history.py
@@ -1,5 +1,6 @@
 import types
 import sys
+import types
 
 
 def test_get_or_create_creates(monkeypatch):
@@ -20,10 +21,19 @@ def test_get_or_create_creates(monkeypatch):
         fake_make_autoname,
     )
 
+    employee = types.SimpleNamespace(company="Test Co", employee_name="John Doe")
+    monkeypatch.setattr(
+        frappe,
+        "get_doc",
+        lambda dt, name: employee if dt == "Employee" else {},
+    )
+
     doc = get_or_create_annual_payroll_history(employee_id="EMP001", fiscal_year="2024")
     assert doc.name == "AUTO-EMP001-2024"
     assert captured["key"] == "EMP001-2024"
     assert doc.fiscal_year == "2024"
+    assert doc.company == "Test Co"
+    assert doc.employee_name == "John Doe"
 
 
 def test_get_or_create_returns_existing(monkeypatch):

--- a/payroll_indonesia/utils/sync_annual_payroll_history.py
+++ b/payroll_indonesia/utils/sync_annual_payroll_history.py
@@ -36,6 +36,11 @@ def get_or_create_annual_payroll_history(employee_id, fiscal_year, create_if_mis
     history.employee = employee_id
     history.fiscal_year = fiscal_year
 
+    # Ambil informasi tambahan dari dokumen Employee
+    employee_doc = frappe.get_doc("Employee", employee_id)
+    history.company = employee_doc.company
+    history.employee_name = getattr(employee_doc, "employee_name", None)
+
     # Gunakan utilitas penamaan Frappe untuk membuat nama unik berdasarkan pola yang diinginkan
     # Depend pada konfigurasi DocType atau pola yang diberikan agar menghasilkan identifier valid
     history.name = make_autoname(f"{employee_id}-{fiscal_year}")


### PR DESCRIPTION
## Summary
- require company on Annual Payroll History DocType
- auto-fill company and employee name when creating history from Employee

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec869fad0832c8e2921ce442c5cdf