### PR TITLE
feat: allow string employee id

### DIFF
--- a/payroll_indonesia/tests/test_sync_error_state.py
+++ b/payroll_indonesia/tests/test_sync_error_state.py
@@ -67,6 +67,81 @@ def test_sync_error_state_forces_save(monkeypatch):
     assert doc.error_state == json.dumps({"detail": "failure"})
 
 
+def test_sync_accepts_employee_string(monkeypatch):
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+    frappe = types.SimpleNamespace()
+
+    class DummyLogger:
+        def info(self, msg):
+            pass
+
+        def warning(self, msg):
+            pass
+
+        def debug(self, msg):
+            pass
+
+    frappe.logger = lambda *a, **k: DummyLogger()
+    frappe.throw = lambda *a, **k: None
+    frappe.log_error = lambda *a, **k: None
+    frappe.db = types.SimpleNamespace(savepoint=lambda name: None, rollback=lambda save_point=None: None)
+    frappe.utils = types.SimpleNamespace(now=lambda: "now")
+    frappe.as_json = json.dumps
+    frappe.session = types.SimpleNamespace(user="tester")
+
+    sys.modules["frappe"] = frappe
+    sys.modules["frappe.utils"] = frappe.utils
+
+    if "payroll_indonesia.utils.sync_annual_payroll_history" in sys.modules:
+        del sys.modules["payroll_indonesia.utils.sync_annual_payroll_history"]
+    sync_mod = importlib.import_module("payroll_indonesia.utils.sync_annual_payroll_history")
+
+    class Detail:
+        def __init__(self):
+            pass
+
+        def set(self, k, v):
+            setattr(self, k, v)
+
+    class HistoryDoc:
+        def __init__(self):
+            self.name = "APH-1"
+            self.flags = types.SimpleNamespace()
+            self.saved = False
+            self.monthly_details = []
+
+        def is_new(self):
+            return False
+
+        def get(self, key, default=None):
+            return getattr(self, key, default)
+
+        def set(self, key, value):
+            setattr(self, key, value)
+
+        def append(self, child_table, data):
+            detail = Detail()
+            self.monthly_details.append(detail)
+            return detail
+
+        def save(self):
+            self.saved = True
+
+    doc = HistoryDoc()
+    monkeypatch.setattr(sync_mod, "get_or_create_annual_payroll_history", lambda *a, **k: doc)
+
+    result = sync_mod.sync_annual_payroll_history(
+        employee="EMP1",
+        fiscal_year="2024",
+        monthly_results=[{"bulan": 1}],
+    )
+
+    assert result == "APH-1"
+    assert doc.saved
+    assert len(doc.monthly_details) == 1
+
+
 def test_cancelled_slip_sets_error_state_and_preserves_row(monkeypatch):
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 


### PR DESCRIPTION
## Summary
- allow employee argument to be passed as string id in sync history utilities
- update wrappers to forward string ids
- add regression test for syncing with string employee

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec97d468c832cbc46f39def9f3679