### PR TITLE
Import sync function directly

### DIFF
--- a/payroll_indonesia/override/payroll_entry.py
+++ b/payroll_indonesia/override/payroll_entry.py
@@ -14,7 +14,7 @@ import traceback
 from typing import Callable, Dict, List, Any, Optional, Tuple
 from payroll_indonesia.override.salary_slip import CustomSalarySlip
 from payroll_indonesia.config import get_value
-from payroll_indonesia.utils import sync_annual_payroll_history
+from payroll_indonesia.utils.sync_annual_payroll_history import sync_annual_payroll_history
 from frappe.utils import file_lock
 import os
 import time
@@ -324,7 +324,7 @@ class CustomPayrollEntry(PayrollEntry):
                         
                         # If we have the necessary data, clean up the history entry
                         if fiscal_year:
-                            sync_annual_payroll_history.sync_annual_payroll_history(
+                            sync_annual_payroll_history(
                                 employee=employee_doc,
                                 fiscal_year=fiscal_year,
                                 monthly_results=None,

--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -38,8 +38,8 @@ from frappe.utils.safe_exec import safe_eval
 # Import tax calculation functions directly (better pattern to avoid circular imports)
 from payroll_indonesia.config.pph21_ter import calculate_pph21_TER
 from payroll_indonesia.config.pph21_ter_december import calculate_pph21_december
-# Import utils module so tests can monkeypatch its sync function easily
-from payroll_indonesia.utils import sync_annual_payroll_history
+# Import sync function directly
+from payroll_indonesia.utils.sync_annual_payroll_history import sync_annual_payroll_history
 from payroll_indonesia import _patch_salary_slip_globals
 
 # Setup global logger for consistent logging
@@ -582,7 +582,7 @@ class CustomSalarySlip(SalarySlip):
 
             docname = None
             if mode == "monthly":
-                docname = sync_annual_payroll_history.sync_annual_payroll_history(
+                docname = sync_annual_payroll_history(
                     employee=self.employee,
                     fiscal_year=fiscal_year,
                     monthly_results=[monthly_result],
@@ -600,7 +600,7 @@ class CustomSalarySlip(SalarySlip):
                 # Preserve slab string separately for reporting if available
                 if isinstance(raw_rate, str) and raw_rate:
                     summary["rate_slab"] = raw_rate
-                docname = sync_annual_payroll_history.sync_annual_payroll_history(
+                docname = sync_annual_payroll_history(
                     employee=self.employee,
                     fiscal_year=fiscal_year,
                     monthly_results=[monthly_result],
@@ -652,7 +652,7 @@ class CustomSalarySlip(SalarySlip):
                 )
                 return
 
-            sync_annual_payroll_history.sync_annual_payroll_history(
+            sync_annual_payroll_history(
                 employee=self.employee,
                 fiscal_year=fiscal_year,
                 monthly_results=None,

--- a/payroll_indonesia/tests/test_salary_slip_sync_once.py
+++ b/payroll_indonesia/tests/test_salary_slip_sync_once.py
@@ -37,7 +37,6 @@ def test_salary_slip_validate_submit_sync_once(monkeypatch):
     sys.modules["frappe.utils.safe_exec"] = safe_exec_mod
 
     salary_slip_mod = importlib.import_module("payroll_indonesia.override.salary_slip")
-    sync_mod = importlib.import_module("payroll_indonesia.utils.sync_annual_payroll_history")
     CustomSalarySlip = salary_slip_mod.CustomSalarySlip
 
     calls = []
@@ -46,7 +45,7 @@ def test_salary_slip_validate_submit_sync_once(monkeypatch):
         calls.extend(kwargs.get("monthly_results", []))
         return "APH-001"
 
-    monkeypatch.setattr(sync_mod, "sync_annual_payroll_history", fake_sync)
+    monkeypatch.setattr(salary_slip_mod, "sync_annual_payroll_history", fake_sync)
     monkeypatch.setattr(CustomSalarySlip, "update_pph21_row", lambda self, amt: None, raising=False)
 
     def fake_calc(self):
@@ -108,7 +107,6 @@ def test_salary_slip_on_submit_populates_monthly_detail(monkeypatch):
     sys.modules["frappe.utils.safe_exec"] = safe_exec_mod
 
     salary_slip_mod = importlib.import_module("payroll_indonesia.override.salary_slip")
-    sync_mod = importlib.import_module("payroll_indonesia.utils.sync_annual_payroll_history")
     CustomSalarySlip = salary_slip_mod.CustomSalarySlip
 
     captured = {}
@@ -117,7 +115,7 @@ def test_salary_slip_on_submit_populates_monthly_detail(monkeypatch):
         captured.update(kwargs)
         return "APH-002"
 
-    monkeypatch.setattr(sync_mod, "sync_annual_payroll_history", fake_sync)
+    monkeypatch.setattr(salary_slip_mod, "sync_annual_payroll_history", fake_sync)
     monkeypatch.setattr(CustomSalarySlip, "update_pph21_row", lambda self, amt: None, raising=False)
 
     ss = CustomSalarySlip()


### PR DESCRIPTION
## Summary
- Import `sync_annual_payroll_history` directly in salary slip and payroll entry overrides
- Call the sync helper directly instead of through the utils module
- Update tests to patch the new direct import

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ecf7992a4832c8c33f1b3478df14d