### PR TITLE
Mark annual payroll totals read-only

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.json
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.json
@@ -44,37 +44,43 @@
       "fieldname": "bruto_total",
       "fieldtype": "Currency",
       "label": "Total Bruto",
-      "reqd": 1
+      "reqd": 0,
+      "read_only": 1
     },
     {
       "fieldname": "netto_total",
       "fieldtype": "Currency",
       "label": "Total Netto",
-      "reqd": 1
+      "reqd": 0,
+      "read_only": 1
     },
     {
       "fieldname": "ptkp_annual",
       "fieldtype": "Currency",
       "label": "PTKP Annual",
-      "reqd": 1
+      "reqd": 0,
+      "read_only": 1
     },
     {
       "fieldname": "pkp_annual",
       "fieldtype": "Currency",
       "label": "PKP Annual (Rounded)",
-      "reqd": 1
+      "reqd": 0,
+      "read_only": 1
     },
     {
       "fieldname": "pph21_annual",
       "fieldtype": "Currency",
       "label": "PPh21 Annual",
-      "reqd": 1
+      "reqd": 0,
+      "read_only": 1
     },
     {
       "fieldname": "koreksi_pph21",
       "fieldtype": "Currency",
       "label": "Koreksi PPh21 Desember",
-      "reqd": 1,
+      "reqd": 0,
+      "read_only": 1,
       "description": "pph21_annual - total pph21 Jan-Nov"
     },
     {


### PR DESCRIPTION
## Summary
- Make annual payroll history total fields non-required and read-only to prevent manual edits
- Ensure error tracking field remains on the Annual Payroll History DocType

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688edcaaa54c832c9893e7e70b994631