### PR TITLE
feat: allow annual payroll sync on submitted docs

### DIFF
--- a/payroll_indonesia/utils/sync_annual_payroll_history.py
+++ b/payroll_indonesia/utils/sync_annual_payroll_history.py
@@ -790,6 +790,7 @@ def sync_annual_payroll_history_for_bulan(
 
             history.flags.ignore_links = True
             history.flags.ignore_permissions = True
+            history.flags.ignore_validate_update_after_submit = True  # sync may recalc totals on submitted docs
             history.save()
             
             # Auto-submit the document if still in Draft status


### PR DESCRIPTION
## Summary
- bypass Frappe's post-submission field protection during annual payroll sync

## Testing
- `pytest` (fails: 5 failed, 4 passed)

------
https://chatgpt.com/codex/tasks/task_e_688f6539a17c832cb3b9ba8e8e899654