### PR TITLE
feat: add before cancel confirmation

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.js
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.js
@@ -1,6 +1,15 @@
 frappe.ui.form.on('Annual Payroll History', {
     refresh: function(frm) {
         calculate_totals(frm);
+    },
+    before_cancel: function(frm) {
+        return new Promise((resolve, reject) => {
+            frappe.confirm(
+                __('Are you sure you want to cancel this document?'),
+                () => resolve(),
+                () => reject()
+            );
+        });
     }
 });
 


### PR DESCRIPTION
## Summary
- prompt users to confirm before cancelling annual payroll history records

## Testing
- `pytest` *(fails: 5 failed, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688f66cee4ac832ca7a8972e0ac6a328