### PR TITLE
Handle annual payroll slip cancellation flags

### DIFF
--- a/payroll_indonesia/override/salary_slip.py
+++ b/payroll_indonesia/override/salary_slip.py
@@ -655,6 +655,8 @@ class CustomSalarySlip(SalarySlip):
 
     def on_cancel(self):
         """When slip is cancelled, remove related row from Annual Payroll History."""
+        if getattr(self, "flags", {}).get("from_annual_payroll_cancel"):
+            return
         try:
             # Check if employee exists
             if not hasattr(self, "employee") or not self.employee:

--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.py
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.py
@@ -105,6 +105,7 @@ class AnnualPayrollHistory(Document):
         for slip in slip_docs:
             try:
                 logger.info(f"Cancelling Salary Slip {slip.name}")
+                slip.flags.from_annual_payroll_cancel = True
                 slip.cancel()
                 frappe.db.commit()
                 cancelled.append(slip.name)


### PR DESCRIPTION
## Summary
- avoid recursive Annual Payroll history sync when slip cancelled from Annual Payroll cancellation
- flag slips initiated from Annual Payroll history before cancelling them

## Testing
- `pytest` *(fails: 5 failed, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688f6be7dc9c832cbd9e199aafb3e23c