### PR TITLE
feat: confirm annual history cancellation

### DIFF
--- a/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.js
+++ b/payroll_indonesia/payroll_indonesia/doctype/annual_payroll_history/annual_payroll_history.js
@@ -5,7 +5,12 @@ frappe.ui.form.on('Annual Payroll History', {
     before_cancel: function(frm) {
         return new Promise((resolve, reject) => {
             frappe.confirm(
-                __('Are you sure you want to cancel this document?'),
+                __(
+                    'Urutan pembatalan:<br>' +
+                    '1. Batalkan semua Salary Slip terkait.<br>' +
+                    '2. Batalkan dokumen Annual Payroll History ini.<br><br>' +
+                    'Lanjutkan pembatalan?'
+                ),
                 () => resolve(),
                 () => reject()
             );


### PR DESCRIPTION
## Summary
- add confirmation dialog explaining cancellation order for annual payroll history

## Testing
- `pytest` *(fails: sync_error_state_forces_save, sync_accepts_employee_string, cancelled_slip_sets_error_state_and_preserves_row, test_sync_wrapper_normalizes_and_logs, test_upsert_monthly_detail_handles_error_state)*

------
https://chatgpt.com/codex/tasks/task_e_688f738c118c832c88dd2c72c013ffea