### PR TITLE
Recalculate annual summary after cancelled slip

### DIFF
--- a/payroll_indonesia/tests/test_cancelled_slip_recalculation.py
+++ b/payroll_indonesia/tests/test_cancelled_slip_recalculation.py
@@ -1,0 +1,98 @@
+import os
+import sys
+import types
+import importlib
+import json
+
+
+def test_cancelled_slip_recalculates_summary(monkeypatch):
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+    frappe = types.SimpleNamespace()
+
+    class DummyLogger:
+        def info(self, msg, *args):
+            pass
+
+        def warning(self, msg, *args):
+            pass
+
+        def debug(self, msg, *args):
+            pass
+
+    frappe.logger = lambda *a, **k: DummyLogger()
+    frappe.throw = lambda *a, **k: None
+    frappe.log_error = lambda *a, **k: None
+    frappe.db = types.SimpleNamespace(
+        savepoint=lambda name: None,
+        rollback=lambda save_point=None: None,
+        exists=lambda dt, name: True,
+    )
+    frappe.utils = types.SimpleNamespace(now=lambda: "now")
+    frappe.as_json = json.dumps
+    frappe.session = types.SimpleNamespace(user="tester")
+
+    sys.modules["frappe"] = frappe
+    sys.modules["frappe.utils"] = frappe.utils
+
+    if "payroll_indonesia.utils.sync_annual_payroll_history" in sys.modules:
+        del sys.modules["payroll_indonesia.utils.sync_annual_payroll_history"]
+    sync_mod = importlib.import_module("payroll_indonesia.utils.sync_annual_payroll_history")
+
+    class Detail:
+        def __init__(self, salary_slip, bruto, pengurang_netto, biaya_jabatan, pph21):
+            self.salary_slip = salary_slip
+            self.bruto = bruto
+            self.pengurang_netto = pengurang_netto
+            self.biaya_jabatan = biaya_jabatan
+            self.pph21 = pph21
+
+    class HistoryDoc:
+        def __init__(self):
+            self.name = "APH-1"
+            self.flags = types.SimpleNamespace()
+            self.saved = False
+            self.docstatus = 1
+            self.monthly_details = [
+                Detail("SS-1", 100, 10, 5, 2),
+                Detail("SS-2", 200, 20, 10, 4),
+            ]
+            self.bruto_total = 300
+            self.pengurang_netto_total = 30
+            self.biaya_jabatan_total = 15
+            self.netto_total = 255
+            self.pph21_annual = 0
+            self.koreksi_pph21 = 0
+
+        def is_new(self):
+            return False
+
+        def get(self, key, default=None):
+            return getattr(self, key, default)
+
+        def set(self, key, value):
+            setattr(self, key, value)
+
+        def save(self):
+            self.saved = True
+
+    history = HistoryDoc()
+    monkeypatch.setattr(
+        sync_mod, "get_or_create_annual_payroll_history", lambda *a, **k: history
+    )
+
+    result = sync_mod.sync_annual_payroll_history_for_bulan(
+        employee={"name": "EMP1"},
+        fiscal_year="2024",
+        cancelled_salary_slip="SS-2",
+    )
+
+    assert result == "APH-1"
+    assert history.saved
+    assert len(history.monthly_details) == 1
+    assert history.bruto_total == 100
+    assert history.pengurang_netto_total == 10
+    assert history.biaya_jabatan_total == 5
+    assert history.netto_total == 85
+    assert history.pph21_annual == 2
+    assert history.koreksi_pph21 == 0

--- a/payroll_indonesia/tests/test_sync_error_state.py
+++ b/payroll_indonesia/tests/test_sync_error_state.py
@@ -11,13 +11,13 @@ def test_sync_error_state_forces_save(monkeypatch):
     frappe = types.SimpleNamespace()
 
     class DummyLogger:
-        def info(self, msg):
+        def info(self, msg, *args):
             pass
 
-        def warning(self, msg):
+        def warning(self, msg, *args):
             pass
 
-        def debug(self, msg):
+        def debug(self, msg, *args):
             pass
 
     frappe.logger = lambda *a, **k: DummyLogger()
@@ -40,6 +40,7 @@ def test_sync_error_state_forces_save(monkeypatch):
             self.name = "APH-1"
             self.flags = types.SimpleNamespace()
             self.saved = False
+            self.docstatus = 1
 
         def is_new(self):
             return False
@@ -73,13 +74,13 @@ def test_sync_accepts_employee_string(monkeypatch):
     frappe = types.SimpleNamespace()
 
     class DummyLogger:
-        def info(self, msg):
+        def info(self, msg, *args):
             pass
 
-        def warning(self, msg):
+        def warning(self, msg, *args):
             pass
 
-        def debug(self, msg):
+        def debug(self, msg, *args):
             pass
 
     frappe.logger = lambda *a, **k: DummyLogger()
@@ -110,6 +111,7 @@ def test_sync_accepts_employee_string(monkeypatch):
             self.flags = types.SimpleNamespace()
             self.saved = False
             self.monthly_details = []
+            self.docstatus = 1
 
         def is_new(self):
             return False
@@ -148,13 +150,13 @@ def test_cancelled_slip_sets_error_state_and_preserves_row(monkeypatch):
     frappe = types.SimpleNamespace()
 
     class DummyLogger:
-        def info(self, msg):
+        def info(self, msg, *args):
             pass
 
-        def warning(self, msg):
+        def warning(self, msg, *args):
             pass
 
-        def debug(self, msg):
+        def debug(self, msg, *args):
             pass
 
     frappe.logger = lambda *a, **k: DummyLogger()
@@ -187,6 +189,7 @@ def test_cancelled_slip_sets_error_state_and_preserves_row(monkeypatch):
             self.flags = types.SimpleNamespace()
             self.saved = False
             self.monthly_details = [Detail()]
+            self.docstatus = 1
 
         def is_new(self):
             return False

--- a/payroll_indonesia/tests/test_sync_wrapper_logging.py
+++ b/payroll_indonesia/tests/test_sync_wrapper_logging.py
@@ -12,13 +12,13 @@ def test_wrapper_normalizes_and_logs(monkeypatch):
         def __init__(self):
             self.debug_messages = []
 
-        def debug(self, msg):
-            self.debug_messages.append(msg)
+        def debug(self, msg, *args):
+            self.debug_messages.append(msg % args if args else msg)
 
-        def info(self, msg):
+        def info(self, msg, *args):
             pass
 
-        def warning(self, msg):
+        def warning(self, msg, *args):
             pass
 
     logger = DummyLogger()

--- a/payroll_indonesia/tests/test_upsert_monthly_detail.py
+++ b/payroll_indonesia/tests/test_upsert_monthly_detail.py
@@ -25,8 +25,10 @@ def test_upsert_monthly_detail_handles_error_state(monkeypatch):
 
     history = HistoryDoc()
 
+    import json
+
     assert upsert_monthly_detail(history, {'bulan': 1, 'error_state': 'oops'})
-    assert history.monthly_details[0].error_state == 'oops'
+    assert history.monthly_details[0].error_state == json.dumps('oops')
 
     assert upsert_monthly_detail(history, {'bulan': 1, 'error_state': 'new'})
-    assert history.monthly_details[0].error_state == 'new'
+    assert history.monthly_details[0].error_state == json.dumps('new')

--- a/payroll_indonesia/utils/sync_annual_payroll_history.py
+++ b/payroll_indonesia/utils/sync_annual_payroll_history.py
@@ -770,8 +770,10 @@ def sync_annual_payroll_history_for_bulan(
                     if history.get(field) is None:
                         history.set(field, 0)
 
-        # Calculate totals from monthly details if summary is not provided
-        if not summary and monthly_results:
+        # Calculate totals from monthly details when no summary is provided.
+        # Also ensure totals are recalculated when a salary slip is cancelled
+        # without providing new monthly results.
+        if not summary and (monthly_results or cancelled_salary_slip):
             try:
                 # Aggregate monthly details to calculate totals
                 recalculate_summary_from_monthly_details(history)


### PR DESCRIPTION
## Summary
- Recalculate annual payroll summary when a salary slip is cancelled without replacement
- Extend tests for salary slip cancellation and adapt existing tests for JSON error states and logging arguments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7f2de520832cab8f6f707624da1a