### PR TITLE
feat: add tax type field to salary slip

### DIFF
--- a/payroll_indonesia/fixtures/custom_field.json
+++ b/payroll_indonesia/fixtures/custom_field.json
@@ -295,5 +295,25 @@
     "in_list_view": 0,
     "description": "Detail perhitungan PPh21 (JSON)",
     "modified": "2024-01-01 00:00:00"
+  },
+  {
+    "doctype": "Custom Field",
+    "name": "Salary Slip-tax_type",
+    "dt": "Salary Slip",
+    "fieldname": "tax_type",
+    "label": "Tax Type",
+    "fieldtype": "Select",
+    "insert_after": "pph21_info",
+    "options": "TER\nDECEMBER",
+    "reqd": 0,
+    "default": "TER",
+    "depends_on": "",
+    "hidden": 0,
+    "no_copy": 0,
+    "print_hide": 0,
+    "in_filter": 0,
+    "in_list_view": 0,
+    "allow_on_submit": 1,
+    "modified": "2024-01-01 00:00:00"
   }
 ]


### PR DESCRIPTION
## Summary
- add `tax_type` select field to Salary Slip with TER/DECEMBER options

## Testing
- `bench export-fixtures` *(fails: command not found)*
- `bench migrate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f8418e094832c9aae43a490f72958