### PR TITLE
Log December tax correction and prevent negative result

### DIFF
--- a/payroll_indonesia/config/pph21_ter_december.py
+++ b/payroll_indonesia/config/pph21_ter_december.py
@@ -86,12 +86,19 @@ def calculate_pph21_december(
     
     # Calculate annual PPh21 using progressive rates
     pph21_annual = calculate_pph21_progressive(pkp_annual)
-    
+
     # Calculate correction for December
     koreksi_pph21 = pph21_annual - ytd_tax_paid
-    
+
+    frappe.logger().debug(
+        "December PPh21 calculation: pph21_annual=%s, ytd_tax_paid=%s, koreksi_pph21=%s",
+        pph21_annual,
+        ytd_tax_paid,
+        koreksi_pph21,
+    )
+
     # December PPh21 is the positive correction amount (negative means refund, handled separately)
-    pph21_bulan_des = koreksi_pph21 if koreksi_pph21 > 0 else 0
+    pph21_bulan_des = max(0, koreksi_pph21)
     
     # Get tax rates description
     rates = "/".join([f"{rate}%" for _, rate in get_tax_slabs()])


### PR DESCRIPTION
## Summary
- log annual PPh21, YTD tax paid, and calculated correction for December
- ensure December PPh21 does not go negative by using `max(0, koreksi_pph21)`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f876b37e8832c9a5d3e77a70a302a