### PR TITLE
Fix salary component fixture quoting

### DIFF
--- a/payroll_indonesia/fixtures/salary_component.json
+++ b/payroll_indonesia/fixtures/salary_component.json
@@ -224,7 +224,7 @@
     "round_to_the_nearest_integer": 1,
     "disabled": 0,
     "amount_based_on_formula": 1,
-    "formula": "(base if base <= get_bpjs_cap(\"bpjs_health_employer_cap\") else get_bpjs_cap(\"bpjs_health_employer_cap\")) * get_bpjs_rate(\"bpjs_health_employer_rate\") / 100",
+    "formula": "(base if base <= get_bpjs_cap('bpjs_health_employer_cap') else get_bpjs_cap('bpjs_health_employer_cap')) * get_bpjs_rate('bpjs_health_employer_rate') / 100",
     "modified": "2024-01-01 00:00:00"
   },
   {
@@ -242,7 +242,7 @@
     "round_to_the_nearest_integer": 1,
     "disabled": 0,
     "amount_based_on_formula": 1,
-    "formula": "(base if base <= get_bpjs_cap(\"bpjs_jht_employer_cap\") else get_bpjs_cap(\"bpjs_jht_employer_cap\")) * get_bpjs_rate(\"bpjs_jht_employer_rate\") / 100",
+    "formula": "(base if base <= get_bpjs_cap('bpjs_jht_employer_cap') else get_bpjs_cap('bpjs_jht_employer_cap')) * get_bpjs_rate('bpjs_jht_employer_rate') / 100",
     "modified": "2024-01-01 00:00:00"
   },
   {
@@ -260,7 +260,7 @@
     "round_to_the_nearest_integer": 1,
     "disabled": 0,
     "amount_based_on_formula": 1,
-    "formula": "(base if base <= get_bpjs_cap(\"bpjs_pension_employer_cap\") else get_bpjs_cap(\"bpjs_pension_employer_cap\")) * get_bpjs_rate(\"bpjs_pension_employer_rate\") / 100",
+    "formula": "(base if base <= get_bpjs_cap('bpjs_pension_employer_cap') else get_bpjs_cap('bpjs_pension_employer_cap')) * get_bpjs_rate('bpjs_pension_employer_rate') / 100",
     "modified": "2024-01-01 00:00:00"
   },
   {
@@ -278,7 +278,7 @@
     "round_to_the_nearest_integer": 1,
     "disabled": 0,
     "amount_based_on_formula": 1,
-    "formula": "base * get_bpjs_rate(\"bpjs_jkk_rate\") / 100",
+    "formula": "base * get_bpjs_rate('bpjs_jkk_rate') / 100",
     "modified": "2024-01-01 00:00:00"
   },
   {
@@ -296,7 +296,7 @@
     "round_to_the_nearest_integer": 1,
     "disabled": 0,
     "amount_based_on_formula": 1,
-    "formula": "base * get_bpjs_rate(\"bpjs_jkm_rate\") / 100",
+    "formula": "base * get_bpjs_rate('bpjs_jkm_rate') / 100",
     "modified": "2024-01-01 00:00:00"
   },
   {
@@ -314,7 +314,7 @@
     "round_to_the_nearest_integer": 1,
     "disabled": 0,
     "amount_based_on_formula": 1,
-    "formula": "(base if base <= get_bpjs_cap(\"bpjs_health_employee_cap\") else get_bpjs_cap(\"bpjs_health_employee_cap\")) * get_bpjs_rate(\"bpjs_health_employee_rate\") / 100",
+    "formula": "(base if base <= get_bpjs_cap('bpjs_health_employee_cap') else get_bpjs_cap('bpjs_health_employee_cap')) * get_bpjs_rate('bpjs_health_employee_rate') / 100",
     "modified": "2024-01-01 00:00:00"
   },
   {
@@ -332,7 +332,7 @@
     "round_to_the_nearest_integer": 1,
     "disabled": 0,
     "amount_based_on_formula": 1,
-    "formula": "base * get_bpjs_rate(\"bpjs_jht_employee_rate\") / 100",
+    "formula": "base * get_bpjs_rate('bpjs_jht_employee_rate') / 100",
     "modified": "2024-01-01 00:00:00"
   },
   {
@@ -350,7 +350,7 @@
     "round_to_the_nearest_integer": 1,
     "disabled": 0,
     "amount_based_on_formula": 1,
-    "formula": "base * get_bpjs_rate(\"bpjs_pension_employee_rate\") / 100",
+    "formula": "base * get_bpjs_rate('bpjs_pension_employee_rate') / 100",
     "modified": "2024-01-01 00:00:00"
   },
   {
@@ -384,7 +384,7 @@
     "round_to_the_nearest_integer": 1,
     "disabled": 0,
     "amount_based_on_formula": 1,
-    "formula": "(base * get_bpjs_rate(\"biaya_jabatan_rate\") / 100 if base * get_bpjs_rate(\"biaya_jabatan_rate\") / 100 <= get_bpjs_cap(\"biaya_jabatan_cap\") / 12 else get_bpjs_cap(\"biaya_jabatan_cap\") / 12)",
+    "formula": "(base * get_bpjs_rate('biaya_jabatan_rate') / 100 if base * get_bpjs_rate('biaya_jabatan_rate') / 100 <= get_bpjs_cap('biaya_jabatan_cap') / 12 else get_bpjs_cap('biaya_jabatan_cap') / 12)",
     "modified": "2024-01-01 00:00:00"
   },
   {
@@ -402,7 +402,7 @@
     "round_to_the_nearest_integer": 1,
     "disabled": 0,
     "amount_based_on_formula": 1,
-    "formula": "(base if base <= get_bpjs_cap(\"bpjs_health_employer_cap\") else get_bpjs_cap(\"bpjs_health_employer_cap\")) * get_bpjs_rate(\"bpjs_health_employer_rate\") / 100",
+    "formula": "(base if base <= get_bpjs_cap('bpjs_health_employer_cap') else get_bpjs_cap('bpjs_health_employer_cap')) * get_bpjs_rate('bpjs_health_employer_rate') / 100",
     "modified": "2024-01-01 00:00:00"
   },
   {
@@ -420,7 +420,7 @@
     "round_to_the_nearest_integer": 1,
     "disabled": 0,
     "amount_based_on_formula": 1,
-    "formula": "(base if base <= get_bpjs_cap(\"bpjs_jht_employer_cap\") else get_bpjs_cap(\"bpjs_jht_employer_cap\")) * get_bpjs_rate(\"bpjs_jht_employer_rate\") / 100",
+    "formula": "(base if base <= get_bpjs_cap('bpjs_jht_employer_cap') else get_bpjs_cap('bpjs_jht_employer_cap')) * get_bpjs_rate('bpjs_jht_employer_rate') / 100",
     "modified": "2024-01-01 00:00:00"
   },
   {
@@ -438,7 +438,7 @@
     "round_to_the_nearest_integer": 1,
     "disabled": 0,
     "amount_based_on_formula": 1,
-    "formula": "(base if base <= get_bpjs_cap(\"bpjs_pension_employer_cap\") else get_bpjs_cap(\"bpjs_pension_employer_cap\")) * get_bpjs_rate(\"bpjs_pension_employer_rate\") / 100",
+    "formula": "(base if base <= get_bpjs_cap('bpjs_pension_employer_cap') else get_bpjs_cap('bpjs_pension_employer_cap')) * get_bpjs_rate('bpjs_pension_employer_rate') / 100",
     "modified": "2024-01-01 00:00:00"
   },
   {
@@ -456,7 +456,7 @@
     "round_to_the_nearest_integer": 1,
     "disabled": 0,
     "amount_based_on_formula": 1,
-    "formula": "(base if base <= get_bpjs_cap(\"bpjs_jkk_cap\") else get_bpjs_cap(\"bpjs_jkk_cap\")) * get_bpjs_rate(\"bpjs_jkk_rate\") / 100",
+    "formula": "(base if base <= get_bpjs_cap('bpjs_jkk_cap') else get_bpjs_cap('bpjs_jkk_cap')) * get_bpjs_rate('bpjs_jkk_rate') / 100",
     "modified": "2024-01-01 00:00:00"
   },
   {
@@ -474,7 +474,7 @@
     "round_to_the_nearest_integer": 1,
     "disabled": 0,
     "amount_based_on_formula": 1,
-    "formula": "(base if base <= get_bpjs_cap(\"bpjs_jkm_cap\") else get_bpjs_cap(\"bpjs_jkm_cap\")) * get_bpjs_rate(\"bpjs_jkm_rate\") / 100",
+    "formula": "(base if base <= get_bpjs_cap('bpjs_jkm_cap') else get_bpjs_cap('bpjs_jkm_cap')) * get_bpjs_rate('bpjs_jkm_rate') / 100",
     "modified": "2024-01-01 00:00:00"
   }
 ]


### PR DESCRIPTION
### Motivation
- Migration failed with a `JSONDecodeError` when importing fixtures due to embedded double quotes inside formula strings.  
- The `salary_component.json` fixture contains formula expressions that used escaped double quotes which broke `json.loads` during fixture import. 

### Description
- Updated `payroll_indonesia/fixtures/salary_component.json` to replace inner double quotes with single quotes inside `formula` strings. 
- Adjusted multiple `formula` fields across salary components to use single-quoted identifiers while preserving the expression logic. 
- Ensured the fixture text remains otherwise unchanged and stays valid JSON. 

### Testing
- Ran a Python JSON parse using `json.loads(open('payroll_indonesia/fixtures/salary_component.json').read())` which completed successfully. 
- Confirmed the previous `json.decoder.JSONDecodeError` no longer occurs when loading the fixture.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69606c5fb5dc832cb7406c29fa68b043)